### PR TITLE
fix: make CPU architecture detection locale-agnostic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ setup_progress_bar_script(){
 
 
 display_what_will_be_installed(){
- 	echo -e "[ OK ] DETECTED OPERATING SYSTEM: ${GREEN} ${NAME^^} $VERSION_ID ${RESET}"
+    echo -e "[ OK ] DETECTED OPERATING SYSTEM: ${GREEN} ${NAME^^} $VERSION_ID ${RESET}"
     if [ -z "$SKIP_REQUIREMENTS" ]; then
 		if [ "$architecture" == "x86_64" ] || [ "$architecture" == "aarch64" ]; then
 	  		echo -e "[ OK ] CPU ARCHITECTURE:          ${GREEN} ${architecture^^} ${RESET}"
@@ -473,8 +473,20 @@ detect_os_cpu_and_package_manager() {
 		        ;;
 		esac
 
-		architecture=$(lscpu | grep Architecture | awk '{print $2}')
-	else
+        # Locale-agnostic CPU architecture detection
+        arch_raw="$(uname -m)"
+        case "$arch_raw" in
+            x86_64|amd64)
+                architecture="x86_64"   # 64-bit x86
+                ;;
+            aarch64|arm64)
+                architecture="aarch64"  # 64-bit ARM
+                ;;
+            *)
+                architecture="$arch_raw" # Fallback: keep raw value
+                ;;
+        esac
+    else
         echo -e "${RED}Could not detect Linux distribution from /etc/os-release${RESET}"
         echo -e "${RED}INSTALL FAILED${RESET}"
         exit 1


### PR DESCRIPTION
## Description

This PR fixes the CPU architecture detection issue that occurs when the system locale is not set to `en_US`. The original implementation used `lscpu | grep Architecture | awk '{print $2}'` which fails on non-English locales because the output is in the local language.

### Problem

On systems with non-US locales (e.g., Serbian), the `lscpu` command outputs architecture information in the local language:

```bash
# Serbian locale output
Архитектура:                  x86_64
```

The original code `lscpu | grep Architecture | awk '{print $2}'` fails because:
1. It searches for "Architecture" (English) but the output is "Архитектура" (Serbian)
2. This causes the installation to fail during CPU architecture detection

### Solution

Replaced the locale-dependent approach with a locale-agnostic solution using `uname -m`:

```bash
# Before (locale-dependent)
architecture=$(lscpu | grep Architecture | awk '{print $2}')

# After (locale-agnostic)
arch_raw="$(uname -m)"
case "$arch_raw" in
    x86_64|amd64)
        architecture="x86_64"   # 64-bit x86
        ;;
    aarch64|arm64)
        architecture="aarch64"  # 64-bit ARM
        ;;
    *)
        architecture="$arch_raw" # Fallback: keep raw value
        ;;
esac
```

### Benefits

- ✅ Works on any locale (English, Serbian, German, etc.)
- ✅ More reliable than parsing `lscpu` output
- ✅ Handles both x86_64 and aarch64 architectures
- ✅ Provides fallback for unknown architectures
- ✅ Maintains backward compatibility

### Testing

The fix has been tested to ensure:
- Architecture detection works on English locales (existing behavior)
- Architecture detection works on non-English locales (new behavior)
- Both x86_64 and aarch64 architectures are properly detected
- Installation proceeds normally after the fix

<img width="1078" height="608" alt="image" src="https://github.com/user-attachments/assets/d95f4d52-b9e0-4935-9eda-730b1373bbc7" />

### Related Issue

Fixes #689 - On install architecture can not be detected if locale is not en_US