### PR TITLE
fix: footer showing template key

### DIFF
--- a/website/src/refine-theme/landing-footer.tsx
+++ b/website/src/refine-theme/landing-footer.tsx
@@ -319,7 +319,7 @@ export const LandingFooter = () => {
                         )}
                     >
                         {
-                            "© {`${currentYear}`}, OpenPanel - made with  "
+                            `© ${currentYear}, OpenPanel - made with  `
                         }
                         <HeartOutlinedIcon
                             className={clsx(


### PR DESCRIPTION
Fixes:
<img width="1179" height="287" alt="image" src="https://github.com/user-attachments/assets/3ff12e25-56b7-447a-8a5b-577555329802" />
