### PR TITLE
Fix IP Script to complete correctly

### DIFF
--- a/opencli/user/ip.sh
+++ b/opencli/user/ip.sh
@@ -230,14 +230,14 @@ if [ "$ACTION" == "delete" ]; then
         rm -rf "$json_file"
     fi
     echo "IP successfully changed for user $USERNAME to shared IP address: $ip_to_use"
+    drop_redis_cache 
 else
-    create_ip_file "$IP"   
-fi
-
-if [ $? -eq 0 ]; then
-    echo "IP successfully changed for user $USERNAME to dedicated IP address: $ip_to_use"
-    drop_redis_cache
-else
-    echo "Failed to set dedicated IP address for user $USERNAME."
-    exit 1
+    create_ip_file "$IP"
+    if [ $? -eq 0 ]; then
+        echo "IP successfully changed for user $USERNAME to dedicated IP address: $ip_to_use"
+        drop_redis_cache
+    else
+        echo "Failed to set dedicated IP address for user $USERNAME."
+        exit 1
+    fi
 fi


### PR DESCRIPTION
fixes switches between dedicated and shared where
/usr/local/opencli/user/ip.sh: line 228: local: can only be used in a
function

Fixes double display of display messages to only show on correct mode
(shared or dedicated - not both)