### PR TITLE
Implement new feature for "es-ES" translations

### DIFF
--- a/translations/es-es/messages.pot
+++ b/translations/es-es/messages.pot
@@ -1,7 +1,6 @@
 # Spanish translations for OpenPanel.
-# Copyright (C) 2024 OPENPANEL
+# Copyright (C) 2025 OPENPANEL
 # This file is distributed under the same license as the OpenPanel project.
-# https://github.com/mendozal, 2024.
 #
 #, fuzzy
 msgid ""
@@ -9,5161 +8,7883 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2024-01-23 11:20+0000\n"
-"PO-Revision-Date: 2024-06-13 16:16-0400\n"
+"PO-Revision-Date: 2025-11-01 21:01-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es_ES\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 3.8\n"
 
-#: modules/backups.py:125 modules/domains.py:233
-msgid "Log file not found."
-msgstr "Archivo de registro no encontrado."
+#: modules/autoinstaller.py:71 templates/dashboard/dashboard.html:146
+#: templates/manager/autoinstaller.html:9
+msgid "Auto Installer"
+msgstr "Auto Instalador"
 
-#: modules/backups.py:271
-msgid "Databases restored successfully"
-msgstr "Bases de datos restauradas correctamente"
+#: modules/crons.py:115
+msgid "CronJobs File Editor"
+msgstr "Editor de archivos de tareas de Cron"
 
-#: modules/backups.py:289
-msgid "Directory not found"
-msgstr "Directorio no encontrado"
-
-#: modules/crons.py:67 templates/dashboard/dashboard.html:397
+#: modules/crons.py:173
 msgid "CronJobs"
-msgstr "CronJobs"
+msgstr "Tareas de Cron"
 
-#: modules/crons.py:92
-msgid "Cron job saved successfully!"
-msgstr "¡Cron job guardado correctamente!"
+#: modules/crons.py:200
+msgid "New CronJob"
+msgstr "Nueva Tarea de Cron"
 
-#: modules/crons.py:94
-msgid "Error saving cron job."
-msgstr "Error al guardar el cron job."
+#: modules/crons.py:235 modules/crons.py:325 modules/crons.py:420
+msgid "Missing one or more required fields (schedule, command, container)."
+msgstr "Falta uno o más campos obligatorios (horario, comando, contenedor)."
 
-#: modules/crons.py:122
-msgid "Cron job successfully modified."
-msgstr "Cronjob modificado con éxito."
+#: modules/crons.py:239
+msgid ""
+"image= or network= are not allowed in the command, crons can only be run on "
+"existing containers."
+msgstr ""
+"image= o network= no están permitidos en el comando, crons sólo puede "
+"ejecutarse en contenedores existentes."
 
-#: modules/crons.py:126
-msgid "Error editing cron job"
-msgstr "Error al editar el cronjob"
+#: modules/crons.py:241 modules/crons.py:273 modules/crons.py:278
+msgid "ERROR: {error_message}"
+msgstr "ERROR: {error_message}"
 
-#: modules/crons.py:137
+#: modules/crons.py:260
+msgid "Cron job created and saved successfully!"
+msgstr "¡Tarea de Cron creada y guardada correctamente!"
+
+#: modules/crons.py:263
+msgid "Error while executing cron commands: "
+msgstr "Error al ejecutar comandos cron:"
+
+#: modules/crons.py:266
+msgid "Unexpected error: "
+msgstr "Error Inesperado:"
+
+#: modules/crons.py:271
+msgid ""
+"image= or network= are not allowed in crontab, crons can only be run on "
+"existing containers."
+msgstr ""
+"image= o network= No se permiten en crontab; los crons solo se pueden "
+"ejecutar en contenedores existentes."
+
+#: modules/crons.py:276
+msgid ""
+"job-service-run, job-local and job-run are not allowed in crontab, crons can "
+"only be run on existing containers with job-exec."
+msgstr ""
+"Los comandos job-service-run, job-local y job-run no están permitidos en "
+"crontab; los crons solo se pueden ejecutar en contenedores existentes con "
+"job-exec."
+
+#: modules/crons.py:287
+msgid "Crontab file saved successfully!"
+msgstr "¡Archivo Crontab guardado correctamente!"
+
+#: modules/crons.py:291
+msgid "Error editing crontab file."
+msgstr "Error al editar el archivo crontab."
+
+#: modules/crons.py:294
+msgid "No cron job or cronfile content provided."
+msgstr ""
+"No se ha proporcionado ningún trabajo cron ni contenido de archivo cron."
+
+#: modules/crons.py:321
+msgid ""
+"Missing the original container fields! (original_schedule, original_command, "
+"original_container, original_comment)."
+msgstr ""
+"¡Faltan los campos del contenedor original! (original_schedule, "
+"original_command, original_container, original_comment)."
+
+#: modules/crons.py:397
+msgid "Cron job was successfully edited."
+msgstr "La tarea Cron se editó correctamente."
+
+#: modules/crons.py:400
+msgid "Error saving cronjob, please try again or use the File Editor instead."
+msgstr ""
+"Error al guardar la tarea cron, inténtelo de nuevo o utilice el editor de "
+"archivos."
+
+#: modules/crons.py:481
 msgid "Cron job was successfully deleted."
-msgstr "El Cronjob se ha eliminado correctamente."
+msgstr "La tarea cron se eliminó correctamente."
 
-#: modules/crons.py:141
-msgid "Error deleting cron job"
-msgstr "Error al eliminar la tarea cron"
+#: modules/crons.py:484
+msgid "Error deleting cron job."
+msgstr "Error al eliminar la tarea cron."
 
-#: modules/dashboard.py:92 modules/dashboard.py:95 modules/dashboard.py:188
-#: modules/dashboard.py:207 modules/dashboard.py:265 modules/dashboard.py:431
-#: modules/ip_blocker.py:25 modules/php.py:228 modules/webserver.py:27
-#: modules/webserver.py:109 modules/webserver.py:145 modules/webserver.py:223
+#: modules/dashboard.py:101 modules/dashboard.py:129
+msgid "User ID not found."
+msgstr "No se encontró el ID de usuario."
+
+#: modules/dashboard.py:118
+msgid "Failed to retrieve system data"
+msgstr "No se pudieron recuperar los datos del sistema."
+
+#: modules/dashboard.py:121
+msgid "Invalid JSON output from Docker command"
+msgstr "Salida JSON no válida del comando Docker"
+
+#: modules/dashboard.py:139
+msgid "Failed to retrieve disk usage information."
+msgstr "No se pudo recuperar la información de uso del disco."
+
+#: modules/dashboard.py:143
+msgid "Disk usage data not found."
+msgstr "No se encontraron datos de uso del disco."
+
+#: modules/dashboard.py:202 modules/dashboard.py:225 modules/dashboard.py:490
+#: modules/docker.py:1066 modules/docker.py:1082 modules/webserver_conf.py:51
 msgid "User not authenticated"
 msgstr "Usuario no autenticado"
 
-#: modules/dashboard.py:166
-msgid "Error fetching country code:"
-msgstr "Error al recuperar el código de país:"
+#: modules/cache/varnish.py:102 modules/dns.py:141 modules/dns.py:211
+#: modules/dns.py:314 modules/dns.py:407 modules/dns.py:442 modules/dns.py:516
+#: modules/dns.py:573 modules/domain/capitalize_domains.py:22
+#: modules/domain/docroot.py:33 modules/domain/domain_logs.py:42
+#: modules/domain/edit_vhost.py:34 modules/domain/edit_vhost.py:56
+#: modules/domain/redirects.py:60 modules/domain/redirects.py:134
+#: modules/domain/redirects.py:197 modules/domain/ssl.py:33
+#: modules/domains.py:410 modules/domains.py:440 modules/domains.py:465
+#: modules/domains.py:494 modules/domains.py:557 modules/emails.py:144
+#: modules/emails.py:277 modules/emails.py:494 modules/emails.py:530
+#: modules/goaccess.py:23 modules/json/screenshots.py:73 modules/mautic.py:111
+#: modules/mautic.py:341 modules/mautic.py:505 modules/mautic.py:698
+#: modules/php.py:524 modules/pm2.py:599 modules/pm2.py:1283
+#: modules/sitemanager/temporary_links.py:54 modules/waf.py:66
+#: modules/waf.py:213 modules/waf.py:261 modules/waf.py:316
+#: modules/website_builder.py:55 modules/website_builder.py:111
+#: modules/website_builder.py:154 modules/website_builder.py:289
+#: modules/websites.py:202 modules/websites.py:333 modules/websites.py:416
+#: modules/websites.py:752 modules/wordpress.py:495 modules/wordpress.py:633
+#: modules/wordpress.py:1152 modules/wordpress.py:1496
+#: modules/wordpress.py:1636
+msgid "You do not own this domain."
+msgstr "Usted no es el propietario de este dominio."
 
-#: modules/dashboard.py:234 modules/dashboard.py:333
-msgid "Error retrieving database count for the user."
-msgstr "Error al recuperar el número de bases de datos para el usuario."
-
-#: modules/dashboard.py:364 modules/dashboard.py:366 modules/dashboard.py:372
-#: modules/dashboard.py:375 templates/edit_mysql_config.html:179
-#: templates/remote_mysql.html:174 templates/ssh.html:197
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: modules/databases.py:187
-msgid ""
-"MySQL configuration was saved successfully but MySQL service failed to "
-"start! Please revert the changes to restart MySQL."
-msgstr ""
-"La configuración de MySQL se ha guardado correctamente, pero el servicio "
-"MySQL no se ha iniciado. Por favor, revierta los cambios para reiniciar "
-"MySQL."
-
-#: modules/databases.py:191
-msgid ""
-"MySQL Configuration was edited successfully and service restarted to apply "
-"new settings."
-msgstr ""
-"La configuración de MySQL se ha editado correctamente y el servicio se ha "
-"reiniciado para aplicar la nueva configuración."
-
-#: modules/databases.py:221
-msgid "Edit MySQL Config"
-msgstr "Editar configuración MySQL"
-
-#: modules/databases.py:238 templates/dashboard/dashboard.html:254
-#: templates/partials/sidebar.html:141
-msgid "MySQL Databases"
-msgstr "Bases de datos MySQL"
-
-#: modules/databases.py:263
-msgid "enabled remote MySQL"
-msgstr "activó MySQL remoto"
-
-#: modules/databases.py:265
-msgid "Remote MySQL access is now enabled."
-msgstr "El acceso remoto MySQL está activado."
-
-#: modules/databases.py:270
-msgid "disabled remote MySQL"
-msgstr "desactivó MySQL remoto"
-
-#: modules/databases.py:272
-msgid "Remote MySQL access is now disabled."
-msgstr "El acceso remoto MySQL está desactivado."
-
-#: modules/databases.py:280
-msgid "ON"
-msgstr "ACTIVADO"
-
-#: modules/databases.py:282
-msgid "OFF"
-msgstr "DESACTIVADO"
-
-#: modules/databases.py:288
-msgid "UNKNOWN"
-msgstr "DESCONOCIDO"
-
-#: modules/databases.py:290 templates/dashboard/dashboard.html:275
-#: templates/partials/sidebar.html:158
-msgid "Remote MySQL"
-msgstr "MySQL remoto"
-
-#: modules/databases.py:310
-msgid "MySQL Processes"
-msgstr "Procesos MySQL"
-
-#: modules/databases.py:432
-msgid "You have reached the maximum number of databases allowed."
-msgstr "Ha alcanzado el número máximo de bases de datos permitidas."
-
-#: modules/disk_usage.py:84 templates/dashboard/dashboard.html:161
-#: templates/partials/sidebar.html:116
-msgid "Disk Usage"
-msgstr "Uso de disco"
-
-#: modules/domains.py:176
-msgid "Both domain_name and file_name are required."
-msgstr "Los campos domain_name y file_name son requeridos."
-
-#: modules/domains.py:182 modules/domains.py:235 modules/domains.py:489
-#: modules/domains.py:586 modules/ip_blocker.py:58 modules/webserver.py:157
-#: modules/websites.py:202 modules/websites.py:234 modules/websites.py:304
-#: modules/websites.py:367 modules/websites.py:415 modules/websites.py:450
-#: modules/websites.py:506 modules/websites.py:561
-msgid "The domain does not belong to the user."
-msgstr "El dominio no pertenece al usuario."
-
-#: modules/domains.py:190
-msgid "Invalid file_name. Allowed values: browser, ip, type, link."
-msgstr ""
-"Campo file_name no válido. Valores permitidos: navegador, ip, tipo, enlace."
-
-#: modules/domains.py:228 modules/domains.py:244
-msgid "Access Log"
-msgstr "Registro de acceso"
-
-#: modules/domains.py:279
-msgid "Invalid data received"
-msgstr "Se han recibido datos no válidos"
-
-#: modules/domains.py:350 templates/_shortcuts.html:143
-#: templates/dashboard/dashboard.html:203
-#: templates/dashboard/dashboard.html:212 templates/partials/sidebar.html:168
-msgid "Domains"
-msgstr "Dominios"
-
-#: modules/domains.py:458
+#: modules/dns.py:233
 msgid "Row deleted successfully"
-msgstr "Filas eliminadas exitosamente"
+msgstr "Fila eliminada correctamente"
 
-#: modules/domains.py:509 modules/domains.py:521
+#: modules/dns.py:362 modules/dns.py:397 templates/domains/domains.html:380
 msgid "Edit DNS Zone"
 msgstr "Editar zona DNS"
 
-#: modules/domains.py:547
+#: modules/dns.py:364 templates/domains/dns.html:95
+#: templates/domains/dns.html:111
+msgid "Edit DNS File"
+msgstr "Editar archivo DNS"
+
+#: modules/dns.py:368
+msgid ""
+"Zone file not found for the subdomain - try editing the zone for apex domain."
+msgstr ""
+"No se encontró el archivo de zona para el subdominio; intente editar la zona "
+"para el dominio raíz."
+
+#: modules/dns.py:370 modules/dns.py:522
 msgid "Zone file not found."
-msgstr "Archivo de zona no encontrado."
+msgstr "No se encontró el archivo de zona."
 
-#: modules/domains.py:570
+#: modules/dns.py:417
+msgid "DNS zone restarted successfully."
+msgstr "La zona DNS se reinició correctamente."
+
+#: modules/dns.py:421
+msgid "Failed to restart DNS zone: "
+msgstr "Error al reiniciar la zona DNS:"
+
+#: modules/dns.py:426 modules/dns.py:428 modules/dns.py:496
+msgid "Please provide a domain name."
+msgstr "Por favor, proporcione un nombre de dominio."
+
+#: modules/dns.py:551
+msgid "CNAME record with this name already exists."
+msgstr "Ya existe un registro CNAME con este nombre."
+
+#: modules/dns.py:559
 msgid "DNS record added successfully."
-msgstr "Registro DNS agregado exitosamente."
+msgstr "Registro DNS añadido correctamente."
 
-#: modules/domains.py:596
+#: modules/dns.py:580
 msgid "DNS zone saved and DNS service restarted."
 msgstr "Zona DNS guardada y servicio DNS reiniciado."
 
-#: modules/domains.py:598
+#: modules/dns.py:583
 msgid "New content not provided."
-msgstr "No se han proporcionado nuevo contenido."
+msgstr "No se ha proporcionado contenido nuevo."
 
-#: modules/domains.py:611
-msgid "Domain name not provided."
-msgstr "No se ha proporcionado el nombre de dominio."
+#: modules/docker.py:182 templates/dashboard/dashboard.html:175
+#: templates/dashboard/usage.html:289 templates/docker/containers.html:8
+#: templates/docker/volumes_TODO.html:9
+msgid "Containers"
+msgstr "Contenedores"
 
-#: modules/domains.py:615
-msgid "Edit VHosts file"
-msgstr "Editar archivo vhosts"
+#: modules/docker.py:329
+msgid "Add service"
+msgstr "Agregar servicio"
 
-#: modules/domains.py:630
-msgid "Invalid request. Domain name and Vhost content must be provided."
+#: modules/docker.py:342 modules/docker.py:540
+msgid ""
+"Invalid service name. Must start with a letter, contain only lowercase "
+"letters and digits, and be at least 3 characters long."
 msgstr ""
-"Solicitud no válida. Se debe proporcionar el nombre de dominio y el "
-"contenido de vhost."
+"Nombre de servicio no válido. Debe comenzar con una letra, contener solo "
+"letras minúsculas y dígitos, y tener al menos 3 caracteres de longitud."
 
-#: modules/domains.py:636 modules/domains.py:638
-msgid "Edit Vhosts"
-msgstr "Editar vhosts"
+#: modules/docker.py:371 modules/docker.py:557
+msgid "CPU limit must be a positive number."
+msgstr "El límite de la CPU debe ser un número positivo."
 
-#: modules/domains.py:636
-msgid "Virtual host configuration saved successfully."
-msgstr "La configuración del Virtual Host se ha guardado correctamente."
-
-#: modules/domains.py:716
-msgid "Error saving virtual host configuration. Configuration test failed."
+#: modules/docker.py:385 modules/docker.py:570
+msgid ""
+"Memory limit must be a positive number followed by 'M' or 'G' (e.g., 512M or "
+"1.5G)."
 msgstr ""
-"Error al guardar la configuración del virtual host. Error en la prueba de "
-"configuración."
+"El límite de memoria debe ser un número positivo seguido de 'M' o 'G' (por "
+"ejemplo, 512M o 1.5G)."
 
-#: modules/domains.py:722
-msgid "Error saving virtual host configuration. An unexpected error occurred."
+#: modules/docker.py:527
+msgid "Service name cannot be changed."
+msgstr "El nombre del servicio no se puede cambiar."
+
+#: modules/docker.py:646
+msgid "Container updated successfully."
+msgstr "Contenedor actualizado correctamente."
+
+#: modules/docker.py:721
+msgid "Delete service"
 msgstr ""
-"Error al guardar la configuración del virtual host. Se ha producido un error "
-"inesperado."
 
-#: modules/domains.py:905
+#: modules/docker.py:923 templates/dashboard/dashboard.html:178
+#: templates/docker/images.html:12
+msgid "Image Updates"
+msgstr ""
+
+#: modules/docker.py:971
+msgid "Change docker image"
+msgstr ""
+
+#: modules/docker.py:995
+msgid "Select docker image"
+msgstr ""
+
+#: modules/docker.py:1057 templates/cache/_shared.html:216
+#: templates/cache/varnish.html:279 templates/dashboard/dashboard.html:177
+#: templates/manager/python_node_apps.html:127
+#: templates/manager/python_node_apps.html:157 templates/manager/ruby.html:138
+#: templates/manager/ruby.html:161 templates/services.html:214
+msgid "Logs"
+msgstr ""
+
+#: modules/docker.py:1086 modules/websites.py:536
+msgid "Invalid action"
+msgstr ""
+
+#: modules/docker.py:1352
+msgid "Select Docker service"
+msgstr ""
+
+#: modules/domains.py:257 templates/cache/varnish.html:122
+#: templates/dashboard/dashboard.html:78 templates/dashboard/dashboard.html:107
+#: templates/dashboard/usage.html:44 templates/domains/domains.html:14
+#: templates/partials/_header.html:64
+msgid "Domains"
+msgstr ""
+
+#: modules/domains.py:355
 msgid ""
 "Error: Reached the maximum allowed number of domains on this hosting plan."
 msgstr ""
-"Error: Se ha alcanzado el número máximo permitido de dominios en este plan "
-"de hosting."
 
-#: modules/domains.py:1105 modules/ssl.py:256
+#: modules/domains.py:389 templates/domains/new.html:130
+#: templates/domains/new.html:344
+msgid "Add Domain"
+msgstr ""
+
+#: modules/domain/docroot.py:21 modules/domain/ssl.py:22 modules/domains.py:401
+#: modules/domains.py:459
+msgid "Invalid request. Domain name must be provided."
+msgstr ""
+
+#: modules/domains.py:437 templates/domains/domains.html:417
+#: templates/emails/single_account.html:102
+#: templates/emails/single_account.html:124
+msgid "Suspend"
+msgstr ""
+
+#: modules/domains.py:491 templates/domains/domains.html:413
+msgid "Unsuspend"
+msgstr ""
+
+#: modules/emails.py:134 modules/emails.py:712 modules/emails.py:725
+#: modules/emails.py:743
+msgid "Error: Invalid email address."
+msgstr ""
+
+#: modules/emails.py:169
+msgid "Filter edited successfully."
+msgstr ""
+
+#: modules/emails.py:173
+msgid "Error editing filter."
+msgstr ""
+
+#: modules/emails.py:177
+msgid "Filters"
+msgstr ""
+
+#: modules/emails.py:257
 msgid ""
-"SSL generation successful. Certificate is present. Modifying Nginx "
-"configuration."
+"Webmail service is not yet started, please contact Administrator to enable "
+"it."
 msgstr ""
-"Generación SSL correcta. El certificado está presente. Modificando la "
-"configuración de Nginx."
 
-#: modules/domains.py:1149 modules/ssl.py:300
-msgid "Nginx configuration modified successfully, restarting nginx.."
-msgstr "Configuración de Nginx modificada con éxito, reiniciando Nginx..."
-
-#: modules/domains.py:1191
-msgid "Invalid URL. Please provide a URL with 'http://' or 'https://' prefix."
+#: modules/emails.py:305 modules/mysqld/mysql_import.py:62
+#: modules/mysqld/mysql_import.py:66 modules/mysqld/mysql_import.py:70
+#: modules/mysqld/mysql_import.py:83 modules/psql/postgresql_import.py:62
+#: modules/psql/postgresql_import.py:67 modules/psql/postgresql_import.py:70
+#: modules/psql/postgresql_import.py:81 templates/psql/databases.html:164
+msgid "Import"
 msgstr ""
-"URL no válida. Introduzca una URL con el prefijo 'http://' o 'https://'."
 
-#: modules/domains.py:1239 modules/ssl.py:163
-msgid "Unauthorized"
-msgstr "No autorizado"
+#: modules/emails.py:309
+msgid "Error: No file uploaded."
+msgstr ""
 
-#: modules/filemanager.py:360
-msgid "File created successfully"
-msgstr "Archivo creado exitosamente"
+#: modules/emails.py:320
+msgid "Error: Unsupported file format, please upload a .csv or .xls file."
+msgstr ""
 
-#: modules/filemanager.py:364
-msgid "Filename is missing"
-msgstr "Falta el nombre del archivo"
+#: modules/emails.py:327
+msgid "Error: File must have at least 2 columns: email, password"
+msgstr ""
 
-#: modules/filemanager.py:392
-msgid "Folder created successfully"
-msgstr "Carpeta creada exitosamente"
+#: modules/emails.py:336
+msgid ""
+"Error: File is invalid - the first column must contain valid email addresses."
+msgstr ""
 
-#: modules/filemanager.py:396
-msgid "Foldername is missing"
-msgstr "Falta el nombre de la carpeta"
+#: modules/emails.py:362
+msgid "Confirm Import"
+msgstr ""
 
-#: modules/filemanager.py:425
-msgid "Files uploaded successfully"
-msgstr "Archivos subidos correctamente"
+#: modules/emails.py:373
+msgid "Error: No import data found, please try again."
+msgstr ""
 
-#: modules/filemanager.py:427
-msgid "No files were uploaded"
-msgstr "No se ha subido ningún archivo"
+#: modules/emails.py:498
+msgid "Error: domain not provided."
+msgstr ""
 
-#: modules/filemanager.py:430
-msgid "Internal server error"
-msgstr "Error interno del servidor"
+#: modules/emails.py:500
+msgid "Error: username not provided."
+msgstr ""
 
-#: modules/filemanager.py:491
-msgid "Unsupported file format"
-msgstr "Formato de archivo no soportado"
+#: modules/emails.py:502
+msgid "Error: password not provided."
+msgstr ""
 
-#: modules/filemanager.py:495
-msgid "File extracted successfully"
-msgstr "Archivo extraído exitosamente"
+#: modules/emails.py:508 templates/files/ftp_new.html:203
+msgid "Create Account"
+msgstr ""
 
-#: modules/filemanager.py:567
-msgid "Archive created successfully"
-msgstr "Archivo creado exitosamente"
+#: modules/emails.py:571 modules/emails.py:573 modules/files/ftp.py:87
+#: modules/files/ftp.py:91 templates/cache/_shared.html:84
+#: templates/cache/varnish.html:105 templates/domains/ssl.html:60
+#: templates/files/ftp.html:17 templates/manager/python_node_apps.html:67
+#: templates/mysql/phpmyadmin.html:88 templates/mysql/remote_mysql.html:101
+#: templates/psql/pgadmin.html:88 templates/psql/remote_psql.html:99
+#: templates/services.html:90 templates/system/ssh.html:52
+msgid "Unknown"
+msgstr ""
 
-#: modules/filemanager.py:638
-msgid "User not authenticated."
-msgstr "Usuario no autenticado."
+#: modules/emails.py:686
+msgid "Accounts"
+msgstr ""
 
-#: modules/filemanager.py:789
-msgid "File Editor"
-msgstr "Editor de archivos"
+#: modules/emails.py:715
+msgid "Delete address"
+msgstr ""
 
-#: modules/filemanager.py:852 modules/filemanager.py:876
-msgid "The specified directory does not exist."
-msgstr "El directorio especificado no existe."
+#: modules/emails.py:734 templates/emails/info.html:9
+msgid "Connect Devices"
+msgstr ""
 
-#: modules/filemanager.py:877 modules/filemanager.py:881
-#: templates/_shortcuts.html:131 templates/dashboard/dashboard.html:148
-#: templates/partials/sidebar.html:93 templates/websites.html:1876
-msgid "File Manager"
-msgstr "Administrador de archivos"
+#: modules/emails.py:748
+msgid "Error: Invalid configuration type."
+msgstr ""
 
-#: modules/fix_permissions.py:69
-msgid "Invalid fix_directory"
-msgstr "Valor fix_directory no válido"
+#: modules/goaccess.py:51 templates/dashboard/dashboard.html:115
+#: templates/domains/goaccess.html:12
+msgid "GoAccess"
+msgstr ""
 
-#: modules/fix_permissions.py:74
-msgid "Success."
-msgstr "Éxito."
-
-#: modules/fix_permissions.py:79 templates/dashboard/dashboard.html:193
-#: templates/fix_permissions.html:17 templates/partials/sidebar.html:132
-msgid "Fix Permissions"
-msgstr "Corregir permisos"
-
-#: modules/inodes.py:88 templates/dashboard/dashboard.html:177
-#: templates/partials/sidebar.html:124
-msgid "Inodes Explorer"
-msgstr "Explorador de inodes"
-
-#: modules/malware_scan.py:65
-msgid "Malware Scanner"
-msgstr "Analizador de malware"
-
-#: modules/malware_scan.py:74
-msgid "No malware found"
-msgstr "No se ha encontrado malware"
-
-#: modules/malware_scan.py:76
-msgid "Malware detected"
-msgstr "Malware detectado"
-
-#: modules/malware_scan.py:78
-msgid "Scan result unknown"
-msgstr "Resultado del análisis desconocido"
-
-#: modules/malware_scan.py:80
-msgid "Connection to ClamAV daemon failed"
-msgstr "Fallo en la conexión con el demonio ClamAV"
-
-#: modules/malware_scan.py:94
-msgid "No directory specified for scanning."
-msgstr "No se ha especificado el directorio para el análisis."
-
-#: modules/malware_scan.py:104
-msgid "Invalid directory specified for scanning."
-msgstr "Directorio especificado para el análisis no válido."
-
-#: modules/php.py:78
-msgid "Invalid input data"
-msgstr "Datos de entrada no válidos"
-
-#: modules/php.py:82 modules/php.py:159 modules/php.py:412 modules/php.py:484
-msgid "success"
-msgstr "éxito"
-
-#: modules/php.py:87
-msgid "Configuration file not found"
-msgstr "Archivo de configuración no encontrado"
-
-#: modules/php.py:161 modules/php.py:414
-msgid "error"
-msgstr "error"
-
-#: modules/php.py:217
-msgid "Error fetching data"
-msgstr "Error al recuperar datos"
-
-#: modules/php.py:278 templates/dashboard/dashboard.html:351
-msgid "PHP.INI Editor"
-msgstr "Editor PHP.INI"
-
-#: modules/php.py:451 templates/dashboard/dashboard.html:334
-#: templates/partials/sidebar.html:318 templates/system/general.html:88
-#: templates/websites.html:2008
-msgid "PHP Settings"
-msgstr "Ajustes PHP"
-
-#: modules/php.py:504
-msgid "User not logged in"
-msgstr "El usuario no ha iniciado sesión"
-
-#: modules/php.py:518
-msgid "No log files found"
-msgstr "No se han encontrado archivos de registro"
-
-#: modules/php.py:538
-msgid "Log file deleted"
-msgstr "Archivo de registro eliminado"
-
-#: modules/phpmyadmin.py:100 modules/terminal.py:49 modules/terminal.py:50
-msgid "Error extracting dbuser and dbpass from Docker container."
-msgstr "Error al extraer dbuser y dbpass del contenedor Docker."
-
-#: modules/phpmyadmin.py:105 modules/terminal.py:53 modules/terminal.py:54
-msgid "Error executing Docker command."
-msgstr "Error al ejecutar el comando Docker."
-
-#: modules/phpmyadmin.py:119
-msgid "Container port not found for the user."
-msgstr "Puerto de contenedor no encontrado para el usuario."
-
-#: modules/process_manager.py:53
-msgid "message"
-msgstr "mensaje"
-
-#: modules/process_manager.py:53
-msgid "Process killed successfully"
-msgstr "Proceso terminado con éxito"
-
-#: modules/process_manager.py:57
-msgid "error_message"
-msgstr "error_message"
-
-#: modules/process_manager.py:91 templates/dashboard/dashboard.html:434
-#: templates/partials/sidebar.html:350
-msgid "Process Manager"
-msgstr "Administrador de procesos"
-
-#: modules/process_manager.py:95
-msgid "Container not found"
-msgstr "Contenedor no encontrado"
-
-#: modules/services.py:52 templates/dashboard/dashboard.html:482
-#: templates/system/general.html:124 templates/system/general.html:127
-#: templates/system/server_info.html:9
+#: modules/info.py:22 templates/dashboard/dashboard.html:196
+#: templates/system/server_info.html:10
 msgid "Server Information"
-msgstr "Información del servidor"
-
-#: modules/services.py:72 templates/dashboard/dashboard.html:474
-msgid "Services Status"
-msgstr "Estado de servicios"
-
-#: modules/ssh.py:44
-msgid "Invalid action"
-msgstr "Acción no válida"
-
-#: modules/ssh.py:58 templates/ssh.html:25
-msgid "Password changed successfully."
-msgstr "Contraseña cambiada exitosamente."
-
-#: modules/ssh.py:69 templates/dashboard/dashboard.html:405
-#: templates/partials/sidebar.html:333
-msgid "SSH Access"
-msgstr "Acceso SSH"
-
-#: modules/ssl.py:103
-msgid "Domain: {} - SSL Expiry Date: {}"
-msgstr "Dominio: {} - Fecha de expiración de SSL: {}"
-
-#: modules/ssl.py:127
-msgid "Domains List:"
-msgstr "Lista de dominios:"
-
-#: modules/ssl.py:129
-msgid "SSL/TLS Settings"
-msgstr "Ajustes SSL/TLS"
-
-#: modules/ssl.py:146
-msgid "Invalid filename"
-msgstr "Nombre de archivo no válido"
-
-#: modules/ssl.py:158
-msgid "Domain not found"
-msgstr "Dominio no encontrado"
-
-#: modules/ssl.py:168
-msgid "Invalid file format. Only .pem files are allowed."
-msgstr "Formato de archivo no válido. Solo son permitidos archivos .pem."
-
-#: modules/ssl.py:178
-msgid "File not found"
-msgstr "Archivo no encontrado"
-
-#: modules/ssl.py:188
-msgid "Invalid request"
-msgstr "Solicitud no válida"
-
-#: modules/ssl.py:233 modules/ssl.py:320
-msgid "User ID is missing"
-msgstr "Falta el ID de usuario"
-
-#: modules/ssl.py:243 modules/ssl.py:330
-msgid "Domain ID or Domain URL is missing"
-msgstr "Falta el ID o la URL del dominio"
-
-#: modules/ssl.py:312
-msgid "An error occurred while generating SSL"
-msgstr "Se ha producido un error al generar el SSL"
-
-#: modules/ssl.py:395
-msgid "Nginx SSL configuration removed successfully, restarting nginx.."
-msgstr "Configuración SSL de Nginx eliminada con éxito, reiniciando nginx.."
-
-#: modules/ssl.py:403 modules/ssl.py:407
-msgid "An error occurred while deleting SSL"
-msgstr "Se ha producido un error al eliminar el SSL"
-
-#: modules/terminal.py:58
-msgid "The ttyd screen session is dead. Cleaning up and starting a new one..."
 msgstr ""
-"La sesión de pantalla ttyd está muerta. Limpiando e iniciando una nueva..."
 
-#: modules/terminal.py:64
-msgid "No ttyd screen session found. Starting a new one..."
+#: modules/mautic.py:140
+msgid "Mautic Manager"
 msgstr ""
-"No se ha encontrado ninguna sesión de pantalla ttyd. Iniciando una nueva..."
 
-#: modules/terminal.py:68
-msgid "The phpmyadmin screen session is active."
-msgstr "La sesión de pantalla phpmyadmin está activa."
-
-#: modules/usage.py:89 templates/dashboard/dashboard.html:425
-#: templates/partials/sidebar.html:290
-msgid "Resource Usage"
-msgstr "Uso de recursos"
-
-#: modules/usage.py:169
-msgid "Container name is required"
-msgstr "Se requiere el nombre del contenedor"
-
-#: modules/usage.py:280
-msgid "Resource Usage History"
-msgstr "Historial de uso de recursos"
-
-#: modules/webserver.py:42
-msgid "Nginx Configuration Editor"
-msgstr "Editor de configuración Nginx"
-
-#: modules/webserver.py:47
-msgid "Apache Configuration Editor"
-msgstr "Editor de configuración Apache"
-
-#: modules/webserver.py:106 templates/partials/sidebar.html:358
-msgid "Server Settings"
-msgstr "Ajustes del servidor"
-
-#: modules/webserver.py:141 templates/dashboard/dashboard.html:466
-msgid "ModSecurity Settings"
-msgstr "Ajustes de ModSecurity"
-
-#: modules/website_builder.py:83
-msgid "My Site"
-msgstr "Mi Sitio"
-
-#: modules/website_builder.py:84
-msgid "My Simple Site"
-msgstr "Mi Sitio Simple"
-
-#: modules/website_builder.py:93
-msgid "Error: .htaccess file already exists. Website creation cannot proceed."
-msgstr ""
-"Error: El archivo .htaccess ya existe. La creación del sitio web no puede "
-"continuar."
-
-#: modules/website_builder.py:128
-msgid "New HTML website was successfully created!"
-msgstr "El nuevo sitio web HTML se ha creado correctamente!"
-
-#: modules/website_builder.py:198 modules/websites.py:695
-#: templates/sites.html:53
-msgid "Website Builder"
-msgstr "Creador de sitios web"
-
-#: modules/websites.py:176
-msgid "expired or not available"
-msgstr "expirado o no disponible"
-
-#: modules/websites.py:179
-msgid "not found"
-msgstr "no encontrado"
-
-#: modules/websites.py:182
-msgid "file not found"
-msgstr "archivo no encontrado"
-
-#: modules/websites.py:342
-msgid "Debugging options updated successfully"
-msgstr "Opciones de depuración actualizadas correctamente"
-
-#: modules/websites.py:394
-msgid "General options edited successfully"
-msgstr "Opciones generales editadas correctamente"
-
-#: modules/websites.py:424 templates/websites.html:1752
-msgid "WordPress updated successfully"
-msgstr "WordPress actualizado correctamente"
-
-#: modules/websites.py:481
-msgid "Update preferences saved successfully"
-msgstr "Las preferencias de actualización se han guardado correctamente"
-
-#: modules/websites.py:660 modules/websites.py:825 templates/sites.html:13
-#: templates/sites.html:92
-msgid "Websites"
-msgstr "Sitios web"
-
-#: modules/websites.py:731
-msgid "Error executing the query:"
-msgstr "Error al ejecutar la consulta:"
-
-#: modules/wordpress.py:131 templates/partials/sidebar.html:75
-msgid "WordPress Manager"
-msgstr "Administrador de WordPress"
-
-#: modules/wordpress.py:205
+#: modules/mautic.py:247
 msgid "Backup restored successfully!"
-msgstr "Copia de seguridad restaurada exitosamente!"
+msgstr ""
 
-#: modules/wordpress.py:267
+#: modules/mautic.py:305 modules/wordpress.py:449
 msgid "Backup completed successfully!"
-msgstr "Copia de seguridad completada exitosamente!"
+msgstr ""
 
-#: modules/wordpress.py:270
+#: modules/mautic.py:308 modules/wordpress.py:453
 msgid "No backup options selected."
-msgstr "Opciones de copia de seguridad no seleccionadas."
+msgstr ""
 
-#: modules/wordpress.py:294
-msgid "Site not found in the database."
-msgstr "Sitio no encontrado en la base de datos."
+#: modules/mautic.py:333 modules/mautic.py:499 modules/website_builder.py:40
+#: modules/wordpress.py:481 modules/wordpress.py:626
+msgid "No data found for the provided site ID"
+msgstr ""
 
-#: modules/wordpress.py:395
-msgid "WordPress removal completed successfully!"
-msgstr "Eliminación de WordPress completada con éxito!"
+#: modules/mautic.py:345
+msgid "Mautic installation not found in the database"
+msgstr ""
 
-#: modules/wordpress.py:399
-msgid "An error occurred during WordPress removal."
-msgstr "Se ha producido un error durante la eliminación de WordPress."
+#: modules/mautic.py:384
+msgid "Database name or user not found in app/config/local.php"
+msgstr ""
 
-#: modules/wordpress.py:424
+#: modules/mautic.py:458
+msgid "Mautic uninstalled successfully!"
+msgstr ""
+
+#: modules/mautic.py:463
+msgid "An error occurred during Mautic uninstall."
+msgstr ""
+
+#: modules/mautic.py:521
+msgid "Mautic installation detached from Manager."
+msgstr ""
+
+#: modules/mautic.py:525
+msgid "An error occurred during Mautic detachment. Please try again."
+msgstr ""
+
+#: modules/mautic.py:528
+msgid "An error occurred during Mautic detachment."
+msgstr ""
+
+#: modules/mautic.py:545 templates/manager/mautic_install.html:9
+msgid "Install Mautic"
+msgstr ""
+
+#: modules/mysql.py:119 modules/mysql.py:290 modules/mysql.py:564
+#: modules/mysql.py:757 modules/postgresql.py:79 modules/postgresql.py:568
+msgid "Database name is required."
+msgstr ""
+
+#: modules/mysql.py:184 modules/postgresql.py:148 templates/mysql/new.html:55
+#: templates/psql/new.html:55
+msgid "Create Database"
+msgstr ""
+
+#: modules/mysql.py:199 modules/mysql.py:281 modules/mysql.py:606
+#: modules/mysql.py:650 modules/mysql.py:750 modules/postgresql.py:163
+#: modules/postgresql.py:617 modules/postgresql.py:696
+msgid "User name is required."
+msgstr ""
+
+#: modules/mysql.py:212 modules/postgresql.py:185
+msgid "This username is not allowed."
+msgstr ""
+
+#: modules/mysql.py:235 modules/postgresql.py:206
+#: templates/mysql/mysql_user.html:173 templates/mysql/users.html:69
+#: templates/psql/mysql_user.html:70 templates/psql/psql_user.html:167
+#: templates/psql/users.html:69
+msgid "Create User"
+msgstr ""
+
+#: modules/mysql.py:246 modules/mysql.py:659 modules/mysql.py:773
+#: modules/postgresql.py:228 modules/postgresql.py:718
+msgid "This is a system username that can not be edited."
+msgstr ""
+
+#: modules/mysql.py:249 modules/postgresql.py:231 templates/files/ftp.html:110
+#: templates/mysql/password.html:174 templates/mysql/root_password.html:161
+#: templates/mysql/users.html:103 templates/psql/password.html:168
+#: templates/psql/users.html:120
+#: templates/user/reset_password/set_new_password.html:55
+msgid "Change Password"
+msgstr ""
+
+#: modules/mysql.py:265 modules/postgresql.py:245
+msgid "Wizard"
+msgstr ""
+
+#: modules/mysql.py:301
+msgid "This is a system database that can not be used."
+msgstr ""
+
+#: modules/mysql.py:325 modules/postgresql.py:287
+#: templates/mysql/assign.html:10 templates/mysql/assign.html:67
+#: templates/psql/assign.html:10 templates/psql/assign.html:70
+msgid "Assign User to Database"
+msgstr ""
+
+#: modules/mysql.py:330 modules/postgresql.py:295
+#: templates/mysql/remove.html:64 templates/psql/remove.html:64
+msgid "Remove User from Database"
+msgstr ""
+
+#: modules/mysql.py:426 templates/dashboard/dashboard.html:120
+#: templates/dashboard/dashboard.html:132 templates/dashboard/usage.html:67
+msgid "Databases"
+msgstr ""
+
+#: modules/mysql.py:477 modules/postgresql.py:503
+#: templates/dashboard/dashboard.html:121
+#: templates/dashboard/dashboard.html:133
+msgid "Users"
+msgstr ""
+
+#: modules/mysql.py:504
+msgid "changed MySQL root user password"
+msgstr ""
+
+#: modules/mysql.py:506
+msgid "Successfully changed root password."
+msgstr ""
+
+#: modules/mysql.py:508
+msgid "Error changing MySQL root password - is mysql running?"
+msgstr ""
+
+#: modules/mysql.py:510
+msgid "Change Root Password"
+msgstr ""
+
+#: modules/mysql.py:535 modules/postgresql.py:536
+#: templates/dashboard/dashboard.html:126
+#: templates/dashboard/dashboard.html:137
+msgid "Process List"
+msgstr ""
+
+#: modules/mysql.py:615
+msgid "This is a system username that can not be deleted."
+msgstr ""
+
+#: modules/mysql.py:769
+msgid "This is a system database that can not be edited."
+msgstr ""
+
+#: modules/pgadmin.py:37
+msgid "pgAdmin service is now enabled."
+msgstr ""
+
+#: modules/pgadmin.py:39
+msgid "Failed to start the pgAdmin service. Try restart."
+msgstr ""
+
+#: modules/pgadmin.py:44
+msgid "pgAdmin service is now disabled."
+msgstr ""
+
+#: modules/pgadmin.py:46
+msgid "Failed to stop the pgAdmin service. Try restart."
+msgstr ""
+
+#: modules/pgadmin.py:94 templates/dashboard/dashboard.html:136
+#: templates/psql/pgadmin.html:14
+msgid "pgAdmin"
+msgstr ""
+
+#: modules/pgadmin.py:133 modules/phpmyadmin.py:208
+msgid "Container port not found for the user."
+msgstr ""
+
+#: modules/php.py:159
+msgid "Invalid input data"
+msgstr ""
+
+#: modules/php.py:174 modules/php.py:576
+msgid "success"
+msgstr ""
+
+#: modules/php.py:178
+msgid "Configuration file not found"
+msgstr ""
+
+#: modules/php.py:210
+msgid "Set Default version"
+msgstr ""
+
+#: modules/php.py:228 modules/php.py:231
+msgid ""
+"PHP Limits can not be edited for Litespeed, please use the 'PHP.INI Editor' "
+"or 'PHP Options' instead."
+msgstr ""
+
+#: modules/php.py:296 templates/dashboard/dashboard.html:168
+msgid "Limits"
+msgstr ""
+
+#: modules/php.py:324 templates/dashboard/dashboard.html:171
+msgid "Extensions"
+msgstr ""
+
+#: modules/php.py:508
+msgid ""
+"Only one PHP version can be used on Litespeed, to change version for all "
+"domains use this page."
+msgstr ""
+
+#: modules/php.py:529
+msgid ""
+"For Litespeed PHP version can not be set per-domain. To change version for "
+"all domains, use the 'Default PHP Version' page."
+msgstr ""
+
+#: modules/php.py:530 modules/php.py:578
+msgid "error"
+msgstr ""
+
+#: modules/account/account.py:122 modules/php.py:607
+#: templates/mysql/phpmyadmin.html:113 templates/psql/pgadmin.html:113
+msgid "Settings"
+msgstr ""
+
+#: modules/phpmyadmin.py:55
+msgid "phpMyAdmin service is now enabled."
+msgstr ""
+
+#: modules/phpmyadmin.py:57
+msgid "Failed to start the phpMyAdmin service. Try restart."
+msgstr ""
+
+#: modules/phpmyadmin.py:62
+msgid "phpMyAdmin service is now disabled."
+msgstr ""
+
+#: modules/phpmyadmin.py:64
+msgid "Failed to stop the phpMyAdmin service. Try restart."
+msgstr ""
+
+#: modules/phpmyadmin.py:103
+msgid "Limits saved ({}) - restarting phpMyAdmin service to apply changes"
+msgstr ""
+
+#: modules/phpmyadmin.py:105
+msgid ""
+"Limits saved ({}) - but phpMyAdmin failed to start. Try reverting changes."
+msgstr ""
+
+#: modules/phpmyadmin.py:107
+msgid "No changes or invalid data provided. Try again."
+msgstr ""
+
+#: modules/phpmyadmin.py:152 templates/mysql/phpmyadmin.html:14
+msgid "phpMyAdmin"
+msgstr ""
+
+#: modules/pm2.py:207
+msgid "File path is missing"
+msgstr ""
+
+#: modules/pm2.py:221
+msgid "Invalid file extension. Only .py, or .js are allowed."
+msgstr ""
+
+#: modules/pm2.py:500 templates/manager/pm2_install.html:8
+msgid "Install Application"
+msgstr ""
+
+#: modules/pm2.py:1105
+msgid "Unable to detect container type for the application."
+msgstr ""
+
+#: modules/pm2.py:1113
+msgid "Not a valid type, only NodeJS or Python applications can be edited."
+msgstr ""
+
+#: modules/pm2.py:1117 modules/pm2.py:1317
+msgid "Error connecting to database."
+msgstr ""
+
+#: modules/pm2.py:1157
+msgid "Error saving: Invalid version format (check tags from hub.docker.com)"
+msgstr ""
+
+#: modules/pm2.py:1161
+msgid "Error saving: Requirements must be empty (No) or 1 (Yes)"
+msgstr ""
+
+#: modules/pm2.py:1165
+msgid ""
+"Error saving: Startup file invalid (must start with /var/www/html/, no path "
+"traversal, ends with .js or .py)"
+msgstr ""
+
+#: modules/pm2.py:1169
+msgid ""
+"Error saving: Provided custom startup command is invalid (no path traversal "
+"'..' allowed!)"
+msgstr ""
+
+#: modules/pm2.py:1173
+msgid ""
+"Error saving: Workdir invalid (must start with /var/www/html/, no path "
+"traversal)"
+msgstr ""
+
+#: modules/pm2.py:1177
+msgid "Error saving: CPU core limit provided is not a positive intiger."
+msgstr ""
+
+#: modules/pm2.py:1181
+msgid "Error saving: Memory limit provided is not a positive intiger."
+msgstr ""
+
+#: modules/pm2.py:1238
+msgid ""
+"Changes saved, make sure to restart the application for changes to take "
+"effect."
+msgstr ""
+
+#: modules/pm2.py:1240
+msgid "Environment file not found."
+msgstr ""
+
+#: modules/pm2.py:1303
+msgid "Unable to detect service name for the application."
+msgstr ""
+
+#: modules/pm2.py:1312
+msgid "Not a valid type, only NodeJS or Python applications can be removed."
+msgstr ""
+
+#: modules/postgresql.py:128
+msgid "You have reached the maximum number of databases allowed."
+msgstr ""
+
+#: modules/postgresql.py:140
+msgid "Failed to create database: "
+msgstr ""
+
+#: modules/postgresql.py:259 modules/postgresql.py:845
+msgid "Invalid or missing user name."
+msgstr ""
+
+#: modules/postgresql.py:262 modules/postgresql.py:850
+msgid "Invalid or missing database name."
+msgstr ""
+
+#: modules/postgresql.py:267
+msgid "This is a system database that cannot be used."
+msgstr ""
+
+#: modules/postgresql.py:278
+msgid "Successfully added a user {db_user} to PostgreSQL database"
+msgstr ""
+
+#: modules/postgresql.py:282
+msgid "Failed to assign user to database."
+msgstr ""
+
+#: modules/postgresql.py:317 modules/postgresql.py:450
+msgid ""
+"Postgres container is not running. Please allow a few moments for the "
+"initialization.."
+msgstr ""
+
+#: modules/postgresql.py:418
+msgid "PostgreSQL databases"
+msgstr ""
+
+#: modules/postgresql.py:632
+msgid "This is a system username that cannot be deleted."
+msgstr ""
+
+#: modules/postgresql.py:862
+msgid "This is a system username that cannot be edited."
+msgstr ""
+
+#: modules/postgresql.py:867
+msgid "This is a system database that cannot be edited."
+msgstr ""
+
+#: modules/postgresql.py:883
+msgid ""
+"Successfully revoked all privileges for user {db_user} from PostgreSQL "
+"database {database_name}"
+msgstr ""
+
+#: modules/postgresql.py:888
+msgid ""
+"Failed to revoke privileges for user {db_user} from PostgreSQL database "
+"{database_name}"
+msgstr ""
+
+#: modules/process_manager.py:96 templates/dashboard/dashboard.html:191
+#: templates/system/process_manager.html:9
+msgid "Process Manager"
+msgstr ""
+
+#: modules/services.py:35
+msgid "Choose Service"
+msgstr ""
+
+#: modules/usage.py:73 templates/dashboard/dashboard.html:189
+#: templates/user/stats.html:20
+msgid "Resource Usage"
+msgstr ""
+
+#: modules/usage.py:134 templates/dashboard/dashboard.html:190
+msgid "Resource Usage History"
+msgstr ""
+
+#: modules/waf.py:79
+msgid "Error: IDs should only contain numbers separated by spaces."
+msgstr ""
+
+#: modules/waf.py:84
+msgid "Error: Tags should only contain words, numbers, or symbols."
+msgstr ""
+
+#: modules/waf.py:133
+msgid "WAF configuration updated."
+msgstr ""
+
+#: modules/waf.py:136
+msgid "Error updating WAF!"
+msgstr ""
+
+#: modules/waf.py:139
+msgid "Configuration file not found."
+msgstr ""
+
+#: modules/waf.py:205 templates/system/waf.html:8
+#: templates/system/waf_domain.html:10
+msgid "WAF"
+msgstr ""
+
+#: modules/waf.py:243
+msgid "Error changing WAF status."
+msgstr ""
+
+#: modules/waf.py:285
+msgid "Domain not found or unauthorized"
+msgstr ""
+
+#: modules/waf.py:392 templates/dashboard/dashboard.html:195
+#: templates/system/waf_logs.html:259
+msgid "WAF Logs"
+msgstr ""
+
+#: modules/webserver_conf.py:57
+msgid "Nginx Configuration Editor"
+msgstr ""
+
+#: modules/webserver_conf.py:58
+msgid "Apache Configuration Editor"
+msgstr ""
+
+#: modules/webserver_conf.py:59
+msgid "OpenResty Configuration Editor"
+msgstr ""
+
+#: modules/webserver_conf.py:60
+msgid "OpenLitespeed Configuration Editor"
+msgstr ""
+
+#: modules/webserver_conf.py:61
+msgid "Litespeed Configuration Editor"
+msgstr ""
+
+#: modules/webserver_conf.py:66
+msgid "Web Server Configuration Editor"
+msgstr ""
+
+#: modules/website_builder.py:49
+msgid "Website not found in the database"
+msgstr ""
+
+#: modules/website_builder.py:89
+msgid "Website deleted successfully!"
+msgstr ""
+
+#: modules/website_builder.py:95
+msgid "An error occurred during website deletion."
+msgstr ""
+
+#: modules/website_builder.py:126
+msgid "Website detached from Manager."
+msgstr ""
+
+#: modules/website_builder.py:130
+msgid "An error occurred during detachment. Please try again."
+msgstr ""
+
+#: modules/website_builder.py:133
+msgid "An error occurred during detachment."
+msgstr ""
+
+#: modules/website_builder.py:182 modules/websites.py:363
+#: modules/websites.py:789
+msgid "Unable to detect docroot for the domain."
+msgstr ""
+
+#: modules/website_builder.py:187 modules/websites.py:369
+#: modules/websites.py:798
+msgid ""
+"Error connecting to database, please try again. If the issue persists "
+"contact support."
+msgstr ""
+
+#: modules/website_builder.py:244
+msgid "Create Website"
+msgstr ""
+
+#: modules/websites.py:211
+msgid "Data gathering started. Please allow a few minutes for completion."
+msgstr ""
+
+#: modules/websites.py:410
+msgid "Missing required parameters"
+msgstr ""
+
+#: modules/websites.py:461
+msgid "Debugging options updated successfully"
+msgstr ""
+
+#: modules/websites.py:479
+msgid "General options edited successfully"
+msgstr ""
+
+#: modules/websites.py:485 templates/manager/wordpress.html:2377
+msgid "WordPress updated successfully"
+msgstr ""
+
+#: modules/websites.py:504
+msgid "Update preferences saved successfully"
+msgstr ""
+
+#: modules/websites.py:597 modules/websites.py:604
+#: templates/dashboard/usage.html:21 templates/domains/domains.html:125
+#: templates/domains/domains.html:203
+msgid "Websites"
+msgstr ""
+
+#: modules/websites.py:656
+msgid "WEBSITES - Error executing the query!"
+msgstr ""
+
+#: modules/websites.py:668
+msgid "WEBSITES - Reading blogname for WordPress website: {path}"
+msgstr ""
+
+#: modules/websites.py:684
+msgid "WEBSITES - Reading WP admin_email for website: {selected_domain}"
+msgstr ""
+
+#: modules/websites.py:763
+msgid "Invalid domain name format."
+msgstr ""
+
+#: modules/wordpress.py:101
+msgid "WordPress Manager"
+msgstr ""
+
+#: modules/wordpress.py:183 modules/wordpress.py:1523 modules/wordpress.py:1654
+msgid "Domain not found."
+msgstr ""
+
+#: modules/wordpress.py:489
+msgid "WordPress installation not found in the database"
+msgstr ""
+
+#: modules/wordpress.py:537
+msgid "Database name or user not found in wp-config.php"
+msgstr ""
+
+#: modules/wordpress.py:592
+msgid "WordPress uninstalled successfully!"
+msgstr ""
+
+#: modules/wordpress.py:599
+msgid "An error occurred during WordPress uninstall."
+msgstr ""
+
+#: modules/wordpress.py:647
+msgid "WordPress installation detached from Manager."
+msgstr ""
+
+#: modules/wordpress.py:652
+msgid "An error occurred during WordPress detachment. Please try again."
+msgstr ""
+
+#: modules/wordpress.py:655
 msgid "An error occurred during WordPress detachment."
-msgstr "Se ha producido un error durante la desconexión de WordPress."
+msgstr ""
 
-#: modules/wordpress.py:610 modules/wordpress.py:787
+#: modules/wordpress.py:795 modules/wordpress.py:934
 msgid ""
 "Scan completed. Found installations:\n"
 "\n"
 msgstr ""
-"Escaneo completado. Instalaciones encontradas:\n"
-"\n"
 
-#: modules/wordpress.py:640 templates/wordpress.html:104
+#: modules/wordpress.py:824 templates/wordpress.html:450
 msgid "Scan skipped. WordPress installation is currently running."
-msgstr "Escaneo omitido. Una instalación de WordPress se está ejecutando."
-
-#: modules/wordpress.py:854
-msgid ""
-"Error: .htaccess file already exists. WordPress installation cannot proceed!"
 msgstr ""
-"Error: El archivo .htaccess ya existe. La instalación de WordPress no puede "
-"continuar!"
 
-#: modules/wordpress.py:1027
-msgid "Hooray, WordPress was successfully installed!"
-msgstr "Hurra, WordPress se ha instalado correctamente!"
+#: modules/wordpress.py:965 templates/manager/wordpress_install.html:9
+msgid "Install WordPress"
+msgstr ""
 
-#: modules/account/login.py:27 templates/user/account.html:15
-#: templates/user/activity.html:117 templates/user/loginlog.html:12
-#: templates/user/twofa_settings.html:11
+#: modules/wordpress.py:1671
+msgid "Verification completed successfully."
+msgstr ""
+
+#: modules/wordpress.py:1672
+msgid "Verification failed."
+msgstr ""
+
+#: modules/wordpress.py:1677
+msgid "Download completed successfully."
+msgstr ""
+
+#: modules/wordpress.py:1678
+msgid "Download failed."
+msgstr ""
+
+#: modules/wordpress.py:1682
+msgid "Salts shuffled successfully."
+msgstr ""
+
+#: modules/wordpress.py:1683
+msgid "Failed to shuffle salts."
+msgstr ""
+
+#: modules/wordpress.py:1695
+msgid "Unsupported action."
+msgstr ""
+
+#: modules/wordpress.py:1706
+msgid "Invalid action. Use 'enable' or 'disable'."
+msgstr ""
+
+#: modules/wordpress.py:1733
+msgid "Invalid type. Use 'core' or 'plugins'."
+msgstr ""
+
+#: modules/account/forgot_password.py:96 modules/account/forgot_password.py:141
+msgid "Forgot Password"
+msgstr ""
+
+#: modules/account/forgot_password.py:107
+msgid "Password Reset Requested"
+msgstr ""
+
+#: modules/account/forgot_password.py:132
+#: templates/user/reset_password/link_is_sent.html:9
+msgid "Password Reset Link Sent"
+msgstr ""
+
+#: modules/account/forgot_password.py:152
+msgid "Reset link has expired"
+msgstr ""
+
+#: modules/account/forgot_password.py:156
+msgid "Reset link is invalid"
+msgstr ""
+
+#: modules/account/forgot_password.py:162
+msgid "Link has already been used or is invalid"
+msgstr ""
+
+#: modules/account/forgot_password.py:172
+msgid "Passwords do not match"
+msgstr ""
+
+#: modules/account/forgot_password.py:185
+msgid "Your password has been reset. Please log in."
+msgstr ""
+
+#: modules/account/forgot_password.py:192 templates/user/email_template.html:59
+msgid "Reset Password"
+msgstr ""
+
+#: modules/account/locale.py:69 templates/dashboard/dashboard.html:201
+#: templates/user/_login.html:98 templates/user/locale.html:12
+msgid "Change Language"
+msgstr ""
+
+#: modules/account/login.py:41
 msgid "Login"
-msgstr "Iniciar sesión"
+msgstr ""
 
-#: modules/account/login.py:91
+#: modules/account/login.py:165
 msgid "User does not exist."
-msgstr "Usuario no existe."
+msgstr ""
 
-#: modules/account/login.py:93
+#: modules/account/login.py:167
 msgid "Error occurred while trying to auto-login."
-msgstr "Se ha producido un error al intentar iniciar sesión automáticamente."
+msgstr ""
 
-#: modules/account/login.py:97
+#: modules/account/login.py:171
 msgid "Invalid admin token."
-msgstr "Token de administrador no válido."
-
-#: modules/account/login.py:143
-msgid "Invalid username or password. Please try again."
 msgstr ""
-"Nombre de usuario o contraseña no válidos. Por favor, inténtelo de nuevo."
 
-#: modules/account/login.py:169
+#: modules/account/login.py:187
+msgid "Username and password are required."
+msgstr ""
+
+#: modules/account/login.py:195
+msgid "Unable to connect to database."
+msgstr ""
+
+#: modules/account/login.py:203
+msgid "Your account is suspended. Please contact support."
+msgstr ""
+
+#: modules/account/login.py:204
+msgid "Unrecognized account. Please check username."
+msgstr ""
+
+#: modules/account/login.py:226
+msgid "Invalid password. Please try again."
+msgstr ""
+
+#: modules/account/login.py:278
 msgid "Invalid 2FA code. Please try again."
-msgstr "Código 2FA no válido. Por favor, inténtelo de nuevo."
+msgstr ""
 
-#: modules/account/login_history.py:28 templates/dashboard/dashboard.html:527
+#: modules/account/login_history.py:21 templates/dashboard/dashboard.html:207
+#: templates/user/loginlog.html:11
 msgid "Login History"
-msgstr "Historial de inicios de sesión"
-
-#: modules/account/settings.py:98
-msgid "Account Settings"
-msgstr "Ajustes de la cuenta"
-
-#: modules/account/twofa.py:109
-msgid "Two-Factor Authentication has been enabled."
-msgstr "Se ha activado la autenticación de dos factores."
-
-#: modules/account/twofa.py:113
-msgid "Two-Factor Authentication has been disabled."
-msgstr "Se ha desactivado la autenticación de dos factores."
-
-#: modules/account/twofa.py:124 modules/account/twofa.py:127
-msgid "2FA Settings"
-msgstr "Ajustes de 2FA"
-
-#: modules/cache/elasticsearch.py:57 modules/cache/elasticsearch.py:63
-msgid "Elasticsearch installed successfully."
-msgstr "Elasticsearch se ha instalado correctamente."
-
-#: modules/cache/elasticsearch.py:66 modules/cache/elasticsearch.py:70
-msgid "Error: Elasticsearch installation failed."
-msgstr "Error: La instalación de Elasticsearch ha fallado."
-
-#: modules/cache/elasticsearch.py:82
-msgid "Elasticsearch is now enabled."
-msgstr "El servicio Elasticsearch está activado."
-
-#: modules/cache/elasticsearch.py:88
-msgid "Elasticsearch service is now disabled."
-msgstr "El servicio Elasticsearch está desactivado."
-
-#: modules/cache/elasticsearch.py:103
-msgid "Elasticsearch"
-msgstr "Elasticsearch"
-
-#: modules/cache/memcached.py:55 modules/cache/memcached.py:61
-msgid "Memcached installed successfully."
-msgstr "Memcached se ha instalado correctamente."
-
-#: modules/cache/memcached.py:64 modules/cache/memcached.py:68
-msgid "Error: Memcached installation failed."
-msgstr "Error: La instalación de Memcached ha fallado."
-
-#: modules/cache/memcached.py:82
-msgid "Memcached service is now enabled."
-msgstr "El servicio Memcached está activado."
-
-#: modules/cache/memcached.py:88
-msgid "Memcached service is now disabled."
-msgstr "El servicio Memcached está desactivado."
-
-#: modules/cache/memcached.py:97
-msgid ""
-"Memory limit for Memcached service successfully changed and service "
-"restarted to apply new limits."
 msgstr ""
-"El límite de memoria del servicio Memcached se ha modificado correctamente y "
-"el servicio se ha reiniciado para aplicar los nuevos límites."
 
-#: modules/cache/memcached.py:100 modules/cache/redis.py:106
-msgid "Memory limit is invalid!"
-msgstr "Límite de memoria no válido!"
+#: modules/account/notifications.py:201
+msgid "Notification Preferences"
+msgstr ""
 
-#: modules/cache/memcached.py:122 templates/dashboard/dashboard.html:305
-#: templates/partials/sidebar.html:262
-#: templates/system/services_status.html:135
+#: modules/account/sessions.py:20 modules/account/sessions.py:36
+#: templates/dashboard/dashboard.html:204
+#: templates/user/active_sessions.html:12
+msgid "Active Sessions"
+msgstr ""
+
+#: modules/account/twofa.py:29
+msgid ""
+"OTP code removed and Two-Factor Authentication is now required on new logins."
+msgstr ""
+
+#: modules/account/twofa.py:33
+msgid ""
+"Setup started: Set up the app or save the OTP code, then confirm to remove "
+"it and activate 2FA."
+msgstr ""
+
+#: modules/account/twofa.py:37
+msgid "Two-Factor Authentication is now disabled."
+msgstr ""
+
+#: modules/account/twofa.py:48
+msgid "enableddisabled"
+msgstr ""
+
+#: modules/account/twofa.py:63 templates/dashboard/dashboard.html:203
+#: templates/dashboard/twofa.html:6 templates/user/twofa_settings.html:11
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: modules/cache/elasticsearch.py:19 templates/dashboard/dashboard.html:155
+msgid "ElasticSearch"
+msgstr ""
+
+#: modules/cache/elasticsearch.py:20 modules/cache/memcached.py:28
+msgid ""
+"The leading distributed, RESTful, open source search and analytics engine "
+"designed for speed and reliability."
+msgstr ""
+
+#: modules/cache/memcached.py:27 templates/dashboard/dashboard.html:152
 msgid "Memcached"
-msgstr "Memcached"
-
-#: modules/cache/redis.py:61 modules/cache/redis.py:67
-msgid "REDIS installed successfully."
-msgstr "REDIS se ha instalado correctamente."
-
-#: modules/cache/redis.py:70 modules/cache/redis.py:74
-msgid "Error: REDIS installation failed."
-msgstr "Error: La instalación de REDIS ha fallado."
-
-#: modules/cache/redis.py:86
-msgid "REDIS service is now enabled."
-msgstr "El servicio REDIS está activado."
-
-#: modules/cache/redis.py:92
-msgid "REDIS service is now disabled."
-msgstr "El servicio REDIS está desactivado."
-
-#: modules/cache/redis.py:103
-msgid ""
-"Memory limit for REDIS service successfully changed and service restarted to "
-"apply new limits."
 msgstr ""
-"El límite de memoria para el servicio REDIS se ha modificado correctamente y "
-"el servicio se ha reiniciado para aplicar los nuevos límites."
 
-#: modules/cache/redis.py:132 templates/dashboard/dashboard.html:297
-#: templates/partials/sidebar.html:200
-#: templates/system/services_status.html:123
-msgid "REDIS"
-msgstr "REDIS"
+#: modules/cache/opensearch.py:23 templates/dashboard/dashboard.html:154
+msgid "OpenSearch"
+msgstr ""
 
-#: modules/core/search.py:35 modules/core/search.py:72
+#: modules/cache/opensearch.py:24
+msgid ""
+"OpenSearch is an open-source, distributed search and analytics suite for "
+"large volumes of data. "
+msgstr ""
+
+#: modules/cache/redis.py:22 templates/dashboard/dashboard.html:151
+msgid "Redis"
+msgstr ""
+
+#: modules/cache/redis.py:23
+msgid ""
+"Redis (Remote Dictionary Server) is an in-memory, key/value store that is "
+"used primarily as an application cache or quick-response database."
+msgstr ""
+
+#: modules/cache/varnish.py:83
+msgid "Varnish caching is now enabled."
+msgstr ""
+
+#: modules/cache/varnish.py:85
+msgid "Failed to start the Varnish service. Try restart."
+msgstr ""
+
+#: modules/cache/varnish.py:94
+msgid "Varnish caching is now disabled."
+msgstr ""
+
+#: modules/cache/varnish.py:96
+msgid "Failed to stop the Varnish service. Try restart."
+msgstr ""
+
+#: modules/cache/varnish.py:161 templates/cache/varnish.html:14
+#: templates/dashboard/dashboard.html:153
+msgid "Varnish"
+msgstr ""
+
+#: modules/core/paths.py:39
+msgid "Invalid context"
+msgstr ""
+
+#: modules/core/paths.py:51
+msgid "User volume not found"
+msgstr ""
+
+#: modules/core/paths.py:54
+msgid "Invalid base directory"
+msgstr ""
+
+#: modules/core/paths.py:57
+msgid "Invalid base directory specified."
+msgstr ""
+
+#: modules/core/paths.py:72
+msgid "User root directory not found"
+msgstr ""
+
+#: modules/core/paths.py:75 modules/core/paths.py:136
+msgid "Forbidden"
+msgstr ""
+
+#: modules/core/paths.py:80
+msgid "Path too long"
+msgstr ""
+
+#: modules/core/paths.py:91
+msgid "Invalid characters in filename"
+msgstr ""
+
+#: modules/core/paths.py:102
+msgid "Suspicious path pattern detected"
+msgstr ""
+
+#: modules/core/paths.py:113
+msgid "Symlinks are not allowed"
+msgstr ""
+
+#: modules/core/paths.py:122
+msgid "Path traversal or symlink escape detected"
+msgstr ""
+
+#: modules/core/paths.py:126
+msgid "File or directory not found"
+msgstr ""
+
+#: modules/core/paths.py:132
+msgid "Not found"
+msgstr ""
+
+#: modules/core/search.py:24 modules/core/search.py:69
 msgid "Invalid search query"
-msgstr "Consulta de búsqueda no válida"
+msgstr ""
 
-#: modules/core/search.py:125
-msgid "Error loading JSON data"
-msgstr "Error al cargar datos JSON"
+#: modules/core/search.py:34
+msgid "Invalid file path"
+msgstr ""
 
-#: modules/json/databases_size_info.py:37
+#: modules/core/search.py:79
+msgid "Invalid folder path"
+msgstr ""
+
+#: modules/core/search.py:142
+msgid "Error decoding JSON data"
+msgstr ""
+
+#: modules/core/search.py:145
+msgid "Error reading the file"
+msgstr ""
+
+#: modules/domain/capitalize_domains.py:82
+msgid "Error reading file."
+msgstr ""
+
+#: modules/domain/capitalize_domains.py:85
+msgid "No capitalized domains."
+msgstr ""
+
+#: modules/domain/docroot.py:29 templates/domains/docroot.html:66
+#: templates/domains/domains.html:392
+msgid "Change docroot"
+msgstr ""
+
+#: modules/domain/docroot.py:42
+msgid "docroot must be provided."
+msgstr ""
+
+#: modules/domain/docroot.py:50
+msgid "Docroot must be inside '/var/www/html/' directory."
+msgstr ""
+
+#: modules/domain/domain_logs.py:104
+msgid "Access Logs"
+msgstr ""
+
+#: modules/domain/edit_vhost.py:28
+msgid "Invalid request. Domain name and Vhost content must be provided."
+msgstr ""
+
+#: modules/domain/edit_vhost.py:52
+msgid "Edit VHosts"
+msgstr ""
+
+#: modules/domain/edit_vhost.py:83
+msgid "Error: VirtualHost file could not be saved."
+msgstr ""
+
+#: modules/domain/edit_vhost.py:129
+msgid "Error saving virtual host configuration. Configuration test failed."
+msgstr ""
+
+#: modules/domain/redirects.py:79
+msgid "Unauthorized"
+msgstr ""
+
+#: modules/domain/redirects.py:127 modules/sitemanager/temporary_links.py:49
+msgid "Domain name not provided."
+msgstr ""
+
+#: modules/domain/redirects.py:141
+msgid "Invalid URL. Please provide a URL with 'http://' or 'https://' prefix."
+msgstr ""
+
+#: modules/domain/redirects.py:193
+msgid "Create a Redirect"
+msgstr ""
+
+#: modules/domain/ssl.py:29 templates/dashboard/dashboard.html:110
+#: templates/domains/domains.html:211
+msgid "SSL"
+msgstr ""
+
+#: modules/domain/ssl.py:47
+msgid "key paths must be provided."
+msgstr ""
+
+#: modules/domain/ssl.py:55
+msgid "Public key path must be inside '/var/www/html/' directory."
+msgstr ""
+
+#: modules/domain/ssl.py:61
+msgid "Private key path must be inside '/var/www/html/' directory."
+msgstr ""
+
+#: modules/files/disk_usage.py:59 templates/dashboard/dashboard.html:97
+#: templates/files/disk_usage.html:13
+msgid "Disk Usage"
+msgstr ""
+
+#: modules/files/filemanager.py:93
+msgid "Failed to set ownership for the new file."
+msgstr ""
+
+#: modules/files/filemanager.py:95
+msgid "File created successfully."
+msgstr ""
+
+#: modules/files/filemanager.py:109
+msgid "Error creating file! Check permissions."
+msgstr ""
+
+#: modules/files/filemanager.py:112
+msgid "Unexpected error occurred while creating the file."
+msgstr ""
+
+#: modules/files/filemanager.py:117
+msgid "Filename is missing"
+msgstr ""
+
+#: modules/files/filemanager.py:147
+msgid "Failed to set ownership for the new folder."
+msgstr ""
+
+#: modules/files/filemanager.py:149
+msgid "Folder created successfully."
+msgstr ""
+
+#: modules/files/filemanager.py:158
+msgid "Error creating directory! Check permissions."
+msgstr ""
+
+#: modules/files/filemanager.py:161
+msgid "Unexpected error occurred while creating the folder."
+msgstr ""
+
+#: modules/files/filemanager.py:166
+msgid "Foldername is missing"
+msgstr ""
+
+#: modules/files/filemanager.py:237
+msgid "Files uploaded successfully."
+msgstr ""
+
+#: modules/files/filemanager.py:240
+msgid "Some files failed: "
+msgstr ""
+
+#: modules/files/filemanager.py:244
+msgid "No files were uploaded"
+msgstr ""
+
+#: modules/files/filemanager.py:247
+msgid "Error uploading files: {0}"
+msgstr ""
+
+#: modules/files/filemanager.py:289
+msgid "Failed to set ownership."
+msgstr ""
+
+#: modules/files/filemanager.py:367
+msgid "File extracted successfully"
+msgstr ""
+
+#: modules/files/filemanager.py:415
+msgid "Failed to set ownership for the downloaded file."
+msgstr ""
+
+#: modules/files/filemanager.py:429
+msgid "No URL provided"
+msgstr ""
+
+#: modules/files/filemanager.py:432
+msgid "Failed to download the file"
+msgstr ""
+
+#: modules/files/filemanager.py:435
+msgid "Internal server error"
+msgstr ""
+
+#: modules/files/filemanager.py:459
+msgid "Missing required form data for compression: "
+msgstr ""
+
+#: modules/files/filemanager.py:499
+msgid "Unsupported archive format."
+msgstr ""
+
+#: modules/files/filemanager.py:506
+msgid "Archive creation failed: "
+msgstr ""
+
+#: modules/files/filemanager.py:512
+msgid "FILEMANAGER - Archive created successfully."
+msgstr ""
+
+#: modules/files/filemanager.py:519
+msgid "Failed to set archive ownership"
+msgstr ""
+
+#: modules/files/filemanager.py:667
+msgid "Permissions changed."
+msgstr ""
+
+#: modules/files/filemanager.py:670
+msgid "Error changing permissions!"
+msgstr ""
+
+#: modules/files/filemanager.py:778 modules/files/filemanager.py:947
+msgid "Viewing of this file type is not allowed."
+msgstr ""
+
+#: modules/files/filemanager.py:819
+msgid "File saved successfully"
+msgstr ""
+
+#: modules/files/filemanager.py:822
+msgid "Error saving file: "
+msgstr ""
+
+#: modules/files/filemanager.py:834
+msgid "File is too large to open in the editor (limit is {} MB)"
+msgstr ""
+
+#: modules/files/filemanager.py:837 modules/files/filemanager.py:970
+msgid "Error accessing file size: "
+msgstr ""
+
+#: modules/files/filemanager.py:849
+msgid "Error reading file"
+msgstr ""
+
+#: modules/files/filemanager.py:895
+msgid "Error retrieving file size."
+msgstr ""
+
+#: modules/files/filemanager.py:899
+msgid "Invalid file size retrieved. Possible issue with file."
+msgstr ""
+
+#: modules/files/filemanager.py:967
+msgid "File is too large to view in the browser (limit is {} MB)"
+msgstr ""
+
+#: modules/files/filemanager.py:1021
+msgid "The specified directory does not exist."
+msgstr ""
+
+#: modules/files/filemanager.py:1206 templates/dashboard/dashboard.html:92
+#: templates/files/disk_usage.html:101 templates/files/filemanager.html:31
+#: templates/files/inodes.html:102
+msgid "File Manager"
+msgstr ""
+
+#: modules/files/filemanager.py:1223
+msgid "Error accessing the specified directory."
+msgstr ""
+
+#: modules/files/filemanager.py:1273 templates/dashboard/dashboard.html:102
+#: templates/files/trash.html:12
+msgid "Trash"
+msgstr ""
+
+#: modules/files/filemanager.py:1448
+msgid "Trash emptied successfully"
+msgstr ""
+
+#: modules/files/filemanager.py:1452
+msgid "Unexpected error"
+msgstr ""
+
+#: modules/files/filemanager.py:1473
+msgid "Nothing to restore"
+msgstr ""
+
+#: modules/files/filemanager.py:1518
+msgid "Some items could not be restored."
+msgstr ""
+
+#: modules/files/filemanager.py:1521
+msgid "All items restored successfully"
+msgstr ""
+
+#: modules/files/filemanager.py:1525
+msgid "Unexpected error occurred"
+msgstr ""
+
+#: modules/files/fix_permissions.py:33
+msgid "Invalid fix_directory"
+msgstr ""
+
+#: modules/files/fix_permissions.py:46
+msgid "Success."
+msgstr ""
+
+#: modules/files/fix_permissions.py:56 templates/dashboard/dashboard.html:101
+#: templates/files/fix_permissions.html:13
+#: templates/files/fix_permissions.html:49
+msgid "Fix Permissions"
+msgstr ""
+
+#: modules/files/ftp.py:140 modules/files/ftp.py:163 modules/files/ftp.py:243
+#: modules/files/ftp.py:321
+msgid ""
+"FTP service is not yet started, please contact Administrator to enable it."
+msgstr ""
+
+#: modules/files/ftp.py:151
+msgid "No currenty active FTP connections"
+msgstr ""
+
+#: modules/files/ftp.py:372
+msgid "Invalid configuration type, please use cyberduck or filezilla only!"
+msgstr ""
+
+#: modules/files/ftp.py:382
+msgid "User has no FTP accounts."
+msgstr ""
+
+#: modules/files/ftp.py:400
+msgid "FTP account not found."
+msgstr ""
+
+#: modules/files/inodes.py:48 templates/dashboard/dashboard.html:99
+#: templates/files/inodes.html:13
+msgid "Inodes Explorer"
+msgstr ""
+
+#: modules/files/malware_scan.py:50
+msgid "Malware Scanner"
+msgstr ""
+
+#: modules/files/malware_scan.py:70
+msgid "Malware Quarantine"
+msgstr ""
+
+#: modules/files/malware_scan.py:80
+msgid "No malware found"
+msgstr ""
+
+#: modules/files/malware_scan.py:82
+msgid "Malware detected"
+msgstr ""
+
+#: modules/files/malware_scan.py:84
+msgid "Scan result unknown"
+msgstr ""
+
+#: modules/files/malware_scan.py:86
+msgid "Connection to ClamAV container failed"
+msgstr ""
+
+#: modules/files/malware_scan.py:98
+msgid "No directory specified for scanning."
+msgstr ""
+
+#: modules/files/malware_scan.py:111
+msgid "Invalid directory specified for scanning."
+msgstr ""
+
+#: modules/json/databases_size_info.py:28
 msgid "Invalid unit parameter. Use \"bytes\", \"kb\", \"mb\", or \"gb\"."
 msgstr ""
-"Parámetro de unidad no válido. Utilice \"bytes\", \"kb\", \"mb\" o \"gb\"."
 
-#: modules/json/helpers.py:111
-msgid "URL parameter is missing"
-msgstr "Falta el parámetro de URL"
-
-#: modules/json/helpers.py:118
-msgid "Invalid URL provided"
-msgstr "URL no válida"
-
-#: modules/json/helpers.py:268
+#: modules/json/helpers.py:651
 msgid "Unable to retrieve size"
-msgstr "No se puede recuperar el tamaño"
-
-#: modules/json/helpers.py:666
-msgid "Error: Invalid log file path. It must end with '.log'."
 msgstr ""
-"Error: Ruta de archivo de registro no válida. Debe terminar con '.log'."
 
-#: templates/_shortcuts.html:6
-msgid "Available Keyboard Shortcuts"
-msgstr "Atajos de teclado disponibles"
+#: modules/json/helpers.py:656
+msgid "Database configuration not found"
+msgstr ""
 
-#: templates/_shortcuts.html:15
-msgid "File Manager Shortcuts"
-msgstr "Atajos del Administrador de Archivos"
+#: modules/mysqld/mysql_import.py:68 modules/psql/postgresql_import.py:69
+msgid "No database file uploaded!"
+msgstr ""
 
-#: templates/_shortcuts.html:19 templates/_shortcuts.html:80
-#: templates/_shortcuts.html:112
-msgid "Shortcut"
-msgstr "Atajo"
+#: modules/mysqld/remote_mysql.py:61
+msgid "enabled remote MySQL"
+msgstr ""
 
-#: templates/_shortcuts.html:20 templates/_shortcuts.html:81
-#: templates/databases.html:393 templates/databases.html:431
-msgid "Action"
-msgstr "Acción"
+#: modules/mysqld/remote_mysql.py:64
+msgid "Remote MySQL access is now enabled."
+msgstr ""
 
-#: templates/_shortcuts.html:25
-msgid "Shift + A"
-msgstr "Shift + A"
+#: modules/mysqld/remote_mysql.py:67
+msgid "Remote MySQL access is already disabled."
+msgstr ""
 
-#: templates/_shortcuts.html:26
-msgid "Select All"
-msgstr "Seleccionar todo"
+#: modules/mysqld/remote_mysql.py:70
+msgid "disabled remote MySQL"
+msgstr ""
 
-#: templates/_shortcuts.html:29
-msgid "Shift + N"
-msgstr "Shift + N"
+#: modules/mysqld/remote_mysql.py:72
+msgid "Remote MySQL access is now disabled."
+msgstr ""
 
-#: templates/_shortcuts.html:30
-msgid "Create a New Folder"
-msgstr "Crear una nueva carpeta"
+#: modules/mysqld/remote_mysql.py:80 modules/psql/remote_postgresql.py:54
+msgid "OFF"
+msgstr ""
 
-#: templates/_shortcuts.html:33
-msgid "Shift + U"
-msgstr "Shift + U"
+#: modules/mysqld/remote_mysql.py:82 modules/psql/remote_postgresql.py:56
+msgid "ON"
+msgstr ""
 
-#: templates/_shortcuts.html:34 templates/filemanager.html:2161
-msgid "Upload Files"
-msgstr "Subir archivos"
+#: modules/mysqld/remote_mysql.py:97
+msgid "Remote MySQL"
+msgstr ""
 
-#: templates/_shortcuts.html:37 templates/_shortcuts.html:86
-msgid "Shift + C"
-msgstr "Shift + C"
+#: modules/phpd/php_ini.py:15 templates/dashboard/dashboard.html:170
+msgid "PHP.INI Editor"
+msgstr ""
 
-#: templates/_shortcuts.html:38
-msgid "Copy Files"
-msgstr "Copiar archivos"
+#: modules/phpd/php_options.py:126 templates/emails/accounts.html:57
+#: templates/manager/wordpress.html:138 templates/manager/wordpress.html:165
+msgid "Options"
+msgstr ""
 
-#: templates/_shortcuts.html:41
-msgid "Shift + M"
-msgstr "Shift + M"
+#: modules/psql/postgresql_conf.py:127
+msgid ""
+"PostgreSQL configuration was saved successfully but postgres service failed "
+"to start! Please revert the changes to restart postgres."
+msgstr ""
 
-#: templates/_shortcuts.html:42
-msgid "Move Files"
-msgstr "Mover archivos"
+#: modules/psql/postgresql_conf.py:130
+msgid ""
+"PostgreSQL Configuration was edited successfully and service restarted to "
+"apply new settings."
+msgstr ""
 
-#: templates/_shortcuts.html:45
-msgid "DELETE"
-msgstr "ELIMINAR"
+#: modules/psql/postgresql_conf.py:133 modules/psql/postgresql_import.py:22
+msgid ""
+"postgres container is not running. Please allow a few moments for "
+"initialization.."
+msgstr ""
 
-#: templates/_shortcuts.html:46
-msgid "Delete File"
-msgstr "Borrar archivo"
+#: modules/psql/postgresql_conf.py:152
+msgid "Edit PostgreSQL configuration"
+msgstr ""
 
-#: templates/_shortcuts.html:49
-msgid "Shift + V"
-msgstr "Shift + V"
+#: modules/psql/remote_postgresql.py:32
+msgid "enabled remote PostgreSQL"
+msgstr ""
 
-#: templates/_shortcuts.html:50 templates/filemanager.html:2198
-#: templates/ssl.html:65
-msgid "View File"
-msgstr "Ver archivo"
+#: modules/psql/remote_postgresql.py:35
+msgid "Remote PostgreSQL access is now enabled."
+msgstr ""
 
-#: templates/_shortcuts.html:53
-msgid "Shift + E"
-msgstr "Shift + E"
+#: modules/psql/remote_postgresql.py:39
+msgid "Remote PostgreSQL access is already disabled."
+msgstr ""
 
-#: templates/_shortcuts.html:54
-msgid "Edit File"
-msgstr "Editar archivo"
+#: modules/psql/remote_postgresql.py:43
+msgid "disabled remote PostgreSQL"
+msgstr ""
 
-#: templates/_shortcuts.html:57
-msgid "Shift + R"
-msgstr "Shift + R"
+#: modules/psql/remote_postgresql.py:46
+msgid "Remote PostgreSQL access is now disabled."
+msgstr ""
 
-#: templates/_shortcuts.html:58
-msgid "Rename Files"
-msgstr "Renombrar archivos"
+#: modules/psql/remote_postgresql.py:72
+msgid "Remote PostgreSQL"
+msgstr ""
 
-#: templates/_shortcuts.html:61
-msgid "Shift + Z"
-msgstr "Shift + Z"
-
-#: templates/_shortcuts.html:62
-msgid "Compress Files"
-msgstr "Comprimir archivos"
-
-#: templates/_shortcuts.html:65
-msgid "Shift + X"
-msgstr "Shift + X"
-
-#: templates/_shortcuts.html:66
-msgid "Extract Files"
-msgstr "Extraer archivos"
-
-#: templates/_shortcuts.html:69 templates/_shortcuts.html:130
-msgid "Shift + F"
-msgstr "Shift + F"
-
-#: templates/_shortcuts.html:70 templates/websites.html:173
-msgid "Home"
-msgstr "Inicio"
-
-#: templates/_shortcuts.html:76
-msgid "Resource Usage Shortcuts"
-msgstr "Atajos para el uso de recursos"
-
-#: templates/_shortcuts.html:87
-msgid "Current Resource Usage"
-msgstr "Uso actual de los recursos"
-
-#: templates/_shortcuts.html:90
-msgid "Shift + O"
-msgstr "Shift + O"
-
-#: templates/_shortcuts.html:91
-msgid "Historical (older) Usage"
-msgstr "Uso histórico (antiguo)"
-
-#: templates/_shortcuts.html:94
-msgid "Shift + L"
-msgstr "Shift + L"
-
-#: templates/_shortcuts.html:95
-msgid "View logs"
-msgstr "Ver registros"
-
-#: templates/_shortcuts.html:107
-msgid "Global Shortcuts"
-msgstr "Atajos globales"
-
-#: templates/_shortcuts.html:113
-msgid "Page"
-msgstr "Página"
-
-#: templates/_shortcuts.html:118 templates/dashboard/dashboard.html:604
-msgid "/"
-msgstr "/"
-
-#: templates/_shortcuts.html:119 templates/base.html:575
-msgid "Search"
-msgstr "Buscar"
-
-#: templates/_shortcuts.html:122
-msgid "Shift + H"
-msgstr "Shift + H"
-
-#: templates/_shortcuts.html:123
+#: templates/base.html:113
 msgid "Dashboard"
-msgstr "Tablero"
-
-#: templates/_shortcuts.html:126
-msgid "Shift + W"
-msgstr "Shift + W"
-
-#: templates/_shortcuts.html:127 templates/base.html:172
-#: templates/base.html:632 templates/dashboard/dashboard.html:119
-#: templates/sites.html:41 templates/wordpress.html:642
-#: templates/wordpress.html:828
-msgid "WordPress"
-msgstr "WordPress"
-
-#: templates/_shortcuts.html:134
-msgid "Shift + B"
-msgstr "Shift + B"
-
-#: templates/_shortcuts.html:135 templates/dashboard/dashboard.html:244
-#: templates/databases.html:368 templates/partials/sidebar.html:136
-msgid "Databases"
-msgstr "Bases de datos"
-
-#: templates/_shortcuts.html:138
-msgid "Shift + P"
-msgstr "Shift + P"
-
-#: templates/_shortcuts.html:139 templates/partials/sidebar.html:150
-#: templates/system/services_status.html:70 templates/websites.html:1914
-msgid "phpMyAdmin"
-msgstr "phpMyAdmin"
-
-#: templates/_shortcuts.html:142
-msgid "Shift + D"
-msgstr "Shift + D"
-
-#: templates/_shortcuts.html:146
-msgid "Shift + Q"
-msgstr "Shift + Q"
-
-#: templates/_shortcuts.html:147 templates/user/account.html:12
-#: templates/user/activity.html:116 templates/user/loginlog.html:11
-#: templates/user/twofa_settings.html:10
-msgid "Activity"
-msgstr "Actividad"
-
-#: templates/_shortcuts.html:150
-msgid "Shift + Y"
-msgstr "Shift + Y"
-
-#: templates/_shortcuts.html:151
-msgid "Usage"
-msgstr "Uso"
-
-#: templates/_shortcuts.html:154
-msgid "Shift + S"
-msgstr "Shift + S"
-
-#: templates/_shortcuts.html:155 templates/system/general.html:52
-msgid "Settings"
-msgstr "Ajustes"
-
-#: templates/apache_nginx_conf_editor.html:52
-msgid "Success"
-msgstr "Éxito"
-
-#: templates/apache_nginx_conf_editor.html:85
-msgid "Here you can edit the main configuration file for your webserver."
 msgstr ""
-"Aquí puede editar el archivo de configuración principal de su servidor web."
 
-#: templates/apache_nginx_conf_editor.html:104
-#: templates/domains/domains.html:478 templates/pm2.html:199
-#: templates/system/modsecurity.html:114 templates/websites.html:755
-msgid "Status"
-msgstr "Estado"
+#: templates/base.html:118 templates/user/favorites.html:13
+msgid "Favorites"
+msgstr ""
 
-#: templates/apache_nginx_conf_editor.html:108 templates/cronjobs.html:716
-#: templates/domains/domains.html:482 templates/domains/edit_dns_zone.html:118
-#: templates/domains/edit_dns_zone.html:346 templates/ftp.html:37
-#: templates/ssl.html:136 templates/wordpress.html:457
+#: templates/base.html:273 templates/manager/sites.html:7
+msgid "Site Manager"
+msgstr ""
+
+#: templates/flarum.html:43
+msgid "Flarum Installation failed."
+msgstr ""
+
+#: templates/flarum.html:56
+msgid "Flarum successfully installed."
+msgstr ""
+
+#: templates/flarum.html:77 templates/flarum.html:644
+msgid "Install Flarum"
+msgstr ""
+
+#: templates/flarum.html:78
+msgid "Install Flarum on an existing domain."
+msgstr ""
+
+#: templates/flarum.html:84
+msgid "Website Name:"
+msgstr ""
+
+#: templates/flarum.html:89 templates/manager/mautic_install.html:36
+#: templates/manager/pm2_install.html:144
+#: templates/manager/websitebuilder_install.html:25
+#: templates/manager/wordpress_install.html:80
+msgid "Domain:"
+msgstr ""
+
+#: templates/flarum.html:105 templates/manager/mautic_install.html:59
+#: templates/manager/wordpress_install.html:119
+msgid "Admin Email:"
+msgstr ""
+
+#: templates/flarum.html:182 templates/manager/mautic_install.html:136
+#: templates/manager/wordpress_install.html:191
+msgid "Admin Username:"
+msgstr ""
+
+#: templates/flarum.html:186 templates/manager/mautic_install.html:155
+#: templates/manager/wordpress_install.html:224
+msgid "Admin Password:"
+msgstr ""
+
+#: templates/flarum.html:191 templates/manager/mautic_install.html:169
+#: templates/manager/wordpress_install.html:251
+msgid "Generate"
+msgstr ""
+
+#: templates/flarum.html:271 templates/manager/mautic_install.html:450
+#: templates/manager/pm2_install.html:636
+#: templates/manager/wordpress_install.html:618
+msgid "Start Installation"
+msgstr ""
+
+#: templates/domains/dns.html:202 templates/domains/dns.html:213
+#: templates/domains/new.html:48 templates/emails/new.html:21
+#: templates/flarum.html:337 templates/mautic.html:90
+#: templates/mysql/phpmyadmin.html:156 templates/php/settings.html:155
+#: templates/wordpress.html:95
+msgid "Domain"
+msgstr ""
+
+#: templates/flarum.html:338
+msgid "Flarum Version"
+msgstr ""
+
+#: templates/flarum.html:339 templates/manager/sites.html:68
+#: templates/mautic.html:92 templates/wordpress.html:97
+msgid "Admin Email"
+msgstr ""
+
+#: templates/flarum.html:340 templates/mautic.html:93
+#: templates/wordpress.html:98
+msgid "Created on"
+msgstr ""
+
+#: templates/docker/containers.html:76 templates/domains/dns.html:139
+#: templates/domains/domains.html:160 templates/domains/domains.html:214
+#: templates/files/clamav/quarantine.html:72 templates/files/disk_usage.html:68
+#: templates/files/ftp.html:77 templates/files/inodes.html:69
+#: templates/flarum.html:341 templates/manager/python_node_apps.html:856
+#: templates/manager/ruby.html:433 templates/manager/sites.html:83
+#: templates/mautic.html:94 templates/mysql/databases.html:158
+#: templates/mysql/users.html:88 templates/psql/databases.html:147
+#: templates/psql/users.html:88 templates/system/cronjobs.html:143
+#: templates/system/waf.html:62 templates/user/active_sessions.html:62
+#: templates/user/favorites.html:55 templates/wordpress.html:99
 msgid "Actions"
-msgstr "Acciones"
-
-#: templates/apache_nginx_conf_editor.html:109 templates/edit_file.html:79
-#: templates/edit_mysql_config.html:183 templates/php_ini_editor.html:80
-msgid "Save Changes"
-msgstr "Guardar cambios"
-
-#: templates/backup.html:11 templates/backup.html:154 templates/backup.html:192
-#: templates/websites.html:1411 templates/websites.html:1613
-#: templates/websites.html:2231
-msgid "Restore"
-msgstr "Restaurar"
-
-#: templates/backup.html:23 templates/backup.html:132
-msgid "Restore Files"
-msgstr "Restaurar archivos"
-
-#: templates/backup.html:24
-msgid "Restore your files from backup"
-msgstr "Restaurar sus archivos de la copia de seguridad"
-
-#: templates/backup.html:32
-msgid "Restore Databases"
-msgstr "Restaurar bases de datos"
-
-#: templates/backup.html:32
-msgid "Restore all databases from backup"
-msgstr "Restaurar todas las bases de datos de la copia de seguridad"
-
-#: templates/backup.html:42
-msgid "Backup Storage"
-msgstr "Almacenamiento de copias de seguridad"
-
-#: templates/backup.html:53
-msgid "Total Backups"
-msgstr "Total de copias de seguridad"
-
-#: templates/backup.html:64
-msgid "Storage Used"
-msgstr "Almacenamiento usado"
-
-#: templates/backup.html:71
-msgid "Destination"
-msgstr "Destino"
-
-#: templates/backup.html:75
-msgid "Backup limit for current hosting plan is 100GB"
 msgstr ""
-"El límite de copias de seguridad para el plan de hosting actual es de 100 GB"
 
-#: templates/backup.html:87
-msgid "Backup Logs"
-msgstr "Registros de copias de seguridad"
+#: templates/flarum.html:355 templates/flarum.html:482
+msgid "Delete Flarum website"
+msgstr ""
 
-#: templates/backup.html:99
-msgid "View Full Backup Log"
-msgstr "Ver el registro completo de la copia de seguridad"
-
-#: templates/backup.html:108
-msgid "Restore History"
-msgstr "Historial de restauraciones"
-
-#: templates/backup.html:120
-msgid "View Full Restore Log"
-msgstr "Ver el registro de restauración completo"
-
-#: templates/backup.html:145 templates/backup.html:178
-msgid "No backups available."
-msgstr "No hay copias de seguridad disponibles."
-
-#: templates/backup.html:153 templates/backup.html:191
-#: templates/cronjobs.html:779 templates/domains/domains.html:242
-#: templates/domains/domains.html:267 templates/domains/domains.html:451
-#: templates/domains/edit_dns_zone.html:149
-#: templates/domains/edit_dns_zone.html:282 templates/filemanager.html:1818
-#: templates/filemanager.html:1848 templates/filemanager.html:1980
-#: templates/filemanager.html:2000 templates/filemanager.html:2027
-#: templates/filemanager.html:2063 templates/filemanager.html:2102
-#: templates/ftp.html:132 templates/ftp.html:175 templates/websites.html:2162
-#: templates/websites.html:2207 templates/websites.html:2230
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: templates/backup.html:165
-msgid "Restore MySQL Database"
-msgstr "Restaurar base de datos MySQL"
-
-#: templates/backup.html:171
-msgid "Select a backup date:"
-msgstr "Seleccione una fecha de copia de seguridad:"
-
-#: templates/backup.html:183
-msgid "Select a database:"
-msgstr "Seleccione una base de datos:"
-
-#: templates/base.html:163 templates/base.html:623 templates/sites.html:30
-msgid "What kind of site would you like to create?"
-msgstr "Qué tipo de sitio le gustaría crear?"
-
-#: templates/base.html:208 templates/base.html:667
-msgid "NodeJS / Python"
-msgstr "NodeJS / Python"
-
-#: templates/base.html:239 templates/base.html:300
-msgid "Copy Path to Clipboard"
-msgstr "Copiar ruta al portapapeles"
-
-#: templates/base.html:262
-msgid "Click to display the full path"
-msgstr "Clic para ver la ruta completa"
-
-#: templates/base.html:296
-msgid "Copied to Clipboard!"
-msgstr "Copiado al portapapeles!"
-
-#: templates/base.html:305
-msgid "Unable to copy path to clipboard"
-msgstr "No se puede copiar la ruta en el portapapeles"
-
-#: templates/base.html:359
-msgid "Navigation"
-msgstr "Navegación"
-
-#: templates/base.html:361
-msgid "Search Files & Folders"
-msgstr "Buscar archivos y carpetas"
-
-#: templates/base.html:365
-msgid "Reload"
-msgstr "Recargar"
-
-#: templates/base.html:369
-msgid "New File"
-msgstr "Nuevo archivo"
-
-#: templates/base.html:373
-msgid "New Folder"
-msgstr "Nueva carpeta"
-
-#: templates/base.html:377 templates/filemanager.html:2171
-msgid "Upload"
-msgstr "Subir"
-
-#: templates/cronjobs.html:29
+#: templates/flarum.html:356 templates/flarum.html:483
 msgid ""
-"A cron job is a Linux command used to schedule tasks for future execution. "
-"It allows you to automate repetitive tasks, such as sending notifications or "
-"running scripts at specific intervals."
+"This will irreversibly delete the website, permanently deleting all files "
+"and database."
 msgstr ""
-"Una tarea cron es un comando de Linux utilizado para programar tareas para "
-"su ejecución futura. Permite automatizar tareas repetitivas, como el envío "
-"de notificaciones o la ejecución de scripts a intervalos específicos."
 
-#: templates/cronjobs.html:39
-msgid "Add New Cron Job"
-msgstr "Agregar nuevo Cron Job"
-
-#: templates/cronjobs.html:42 templates/cronjobs.html:86
-#: templates/cronjobs.html:300 templates/cronjobs.html:551
-msgid "-- Common Settings --"
-msgstr "-- Ajustes comunes --"
-
-#: templates/cronjobs.html:45 templates/cronjobs.html:89
-msgid "Once Per Minute"
-msgstr "Una vez por minuto"
-
-#: templates/cronjobs.html:48 templates/cronjobs.html:95
-msgid "Once Per Five Minutes"
-msgstr "Una vez cada cinco minutos"
-
-#: templates/cronjobs.html:51
-msgid "Twice Per Hour"
-msgstr "Dos veces por hora"
-
-#: templates/cronjobs.html:54
-msgid "Once Per Hour"
-msgstr "Una vez por hora"
-
-#: templates/cronjobs.html:57
-msgid "Twice Per Day"
-msgstr "Dos veces por día"
-
-#: templates/cronjobs.html:60
-msgid "Once Per Day"
-msgstr "Una vez por día"
-
-#: templates/cronjobs.html:63
-msgid "Once Per Week"
-msgstr "Una vez por semana"
-
-#: templates/cronjobs.html:66 templates/cronjobs.html:359
-msgid "On the 1st and 15th of the Month"
-msgstr "Los días 1 y 15 de cada mes"
-
-#: templates/cronjobs.html:69
-msgid "Once Per Month"
-msgstr "Una vez al mes"
-
-#: templates/cronjobs.html:72
-msgid "Once Per Year"
-msgstr "Una vez al año"
-
-#: templates/cronjobs.html:78
-msgid "Minute:"
-msgstr "Minuto:"
-
-#: templates/cronjobs.html:82 templates/cronjobs.html:298
-#: templates/cronjobs.html:343 templates/cronjobs.html:467
-#: templates/cronjobs.html:549
-msgid "Common Settings:"
-msgstr "Ajustes comunes:"
-
-#: templates/cronjobs.html:92
-msgid "Once Per Two Minutes"
-msgstr "Una vez cada dos minutos"
-
-#: templates/cronjobs.html:98
-msgid "Once Per Ten Minutes"
-msgstr "Una vez cada diez minutos"
-
-#: templates/cronjobs.html:101
-msgid "Once Per Fifteen Minutes"
-msgstr "Una vez cada quince minutos"
-
-#: templates/cronjobs.html:104
-msgid "Once Per Thirty Minutes"
-msgstr "Una vez cada treinta minutos"
-
-#: templates/cronjobs.html:107
-msgid "-- Minutes --"
-msgstr "-- Minutos --"
-
-#: templates/cronjobs.html:110
-msgid "At the beginning of the hour."
-msgstr "Al comienzo de la hora."
-
-#: templates/cronjobs.html:155
-msgid "At one quarter past the hour."
-msgstr "A un cuarto pasado de la hora."
-
-#: templates/cronjobs.html:200
-msgid "At half past the hour."
-msgstr "A media hora pasada de la hora."
-
-#: templates/cronjobs.html:245
-msgid "At one quarter until the hour."
-msgstr "A un cuarto antes de la hora."
-
-#: templates/cronjobs.html:294
-msgid "Hour:"
-msgstr "Hora:"
-
-#: templates/cronjobs.html:301
-msgid "Every Hour"
-msgstr "Cada hora"
-
-#: templates/cronjobs.html:302
-msgid "Every Other Hour"
-msgstr "Cada dos horas"
-
-#: templates/cronjobs.html:303
-msgid "Every Third Hour"
-msgstr "Cada tres horas"
-
-#: templates/cronjobs.html:304
-msgid "Every Fourth Hour"
-msgstr "Cada cuatro horas"
-
-#: templates/cronjobs.html:305
-msgid "Every Sixth Hour"
-msgstr "Cada seis horas"
-
-#: templates/cronjobs.html:306
-msgid "Every Twelve Hours"
-msgstr "Cada doce horas"
-
-#: templates/cronjobs.html:307
-msgid "-- Hours --"
-msgstr "-- Horas --"
-
-#: templates/cronjobs.html:308
-msgid "a.m.Midnight"
-msgstr "a.m.Media noche"
-
-#: templates/cronjobs.html:309 templates/cronjobs.html:310
-#: templates/cronjobs.html:311 templates/cronjobs.html:312
-#: templates/cronjobs.html:313 templates/cronjobs.html:314
-#: templates/cronjobs.html:315 templates/cronjobs.html:316
-#: templates/cronjobs.html:317 templates/cronjobs.html:318
-#: templates/cronjobs.html:319
-msgid "a.m."
-msgstr "a.m."
-
-#: templates/cronjobs.html:320
-msgid "p.m.Noon"
-msgstr "p.m.Siesta"
-
-#: templates/cronjobs.html:321 templates/cronjobs.html:322
-#: templates/cronjobs.html:323 templates/cronjobs.html:324
-#: templates/cronjobs.html:325 templates/cronjobs.html:326
-#: templates/cronjobs.html:327 templates/cronjobs.html:328
-#: templates/cronjobs.html:329 templates/cronjobs.html:330
-#: templates/cronjobs.html:331
-msgid "p.m."
-msgstr "p.m."
-
-#: templates/cronjobs.html:339
-msgid "Day:"
-msgstr "Día:"
-
-#: templates/cronjobs.html:347 templates/cronjobs.html:470
-msgid "Common Settings"
-msgstr "Ajustes comunes"
-
-#: templates/cronjobs.html:351
-msgid "Every Day"
-msgstr "Cada día"
-
-#: templates/cronjobs.html:355
-msgid "Every Other Day"
-msgstr "Cada dos días"
-
-#: templates/cronjobs.html:363
-msgid "Days"
-msgstr "Dias"
-
-#: templates/cronjobs.html:464
-msgid "Month:"
-msgstr "Mes:"
-
-#: templates/cronjobs.html:473
-msgid "Every Month"
-msgstr "Cada mes"
-
-#: templates/cronjobs.html:477
-msgid "Every Other Month"
-msgstr "Cada dos meses"
-
-#: templates/cronjobs.html:481
-msgid "Every Third Month"
-msgstr "Cada tres meses"
-
-#: templates/cronjobs.html:485
-msgid "Every Six Months"
-msgstr "Cada seis meses"
-
-#: templates/cronjobs.html:489
-msgid "Months"
-msgstr "Meses"
-
-#: templates/cronjobs.html:492
-msgid "January"
-msgstr "Enero"
-
-#: templates/cronjobs.html:496
-msgid "February"
-msgstr "Febrero"
-
-#: templates/cronjobs.html:500
-msgid "March"
-msgstr "Marzo"
-
-#: templates/cronjobs.html:504
-msgid "April"
-msgstr "Abril"
-
-#: templates/cronjobs.html:508
-msgid "May"
-msgstr "Mayo"
-
-#: templates/cronjobs.html:512
-msgid "June"
-msgstr "Junio"
-
-#: templates/cronjobs.html:516
-msgid "July"
-msgstr "Julio"
-
-#: templates/cronjobs.html:520
-msgid "August"
-msgstr "Agosto"
-
-#: templates/cronjobs.html:524
-msgid "September"
-msgstr "Setiembre"
-
-#: templates/cronjobs.html:528
-msgid "October"
-msgstr "Octubre"
-
-#: templates/cronjobs.html:532
-msgid "November"
-msgstr "Noviembre"
-
-#: templates/cronjobs.html:536
-msgid "December"
-msgstr "Diciembre"
-
-#: templates/cronjobs.html:545
-msgid "Weekday:"
-msgstr "Día de la semana:"
-
-#: templates/cronjobs.html:552
-msgid "Every Day (*)"
-msgstr "Cada día (*)"
-
-#: templates/cronjobs.html:553
-msgid "Every Weekday"
-msgstr "Cada día laboral"
-
-#: templates/cronjobs.html:554
-msgid "Every Weekend Day"
-msgstr "Cada día del fin de semana"
-
-#: templates/cronjobs.html:555
-msgid "Every Monday, Wednesday, and Friday"
-msgstr "Cada lunes, miércoles y viernes"
-
-#: templates/cronjobs.html:556
-msgid "Every Tuesday and Thursday"
-msgstr "Cada martes y jueves"
-
-#: templates/cronjobs.html:557
-msgid " -- Weekdays --"
-msgstr " -- Días de la semana --"
-
-#: templates/cronjobs.html:558
-msgid "Sunday"
-msgstr "Domingo"
-
-#: templates/cronjobs.html:559
-msgid "Monday"
-msgstr "Lunes"
-
-#: templates/cronjobs.html:560
-msgid "Tuesday"
-msgstr "Martes"
-
-#: templates/cronjobs.html:561
-msgid "Wednesday"
-msgstr "Miércoles"
-
-#: templates/cronjobs.html:562
-msgid "Thursday "
-msgstr "Jueves "
-
-#: templates/cronjobs.html:563
-msgid "Friday"
-msgstr "Viernes"
-
-#: templates/cronjobs.html:564
-msgid "Saturday"
-msgstr "Sábado"
-
-#: templates/cronjobs.html:569
-msgid "Command:"
-msgstr "Comando:"
-
-#: templates/cronjobs.html:574
-msgid "Schedule CronJob"
-msgstr "Programar CronJob"
-
-#: templates/cronjobs.html:681
-msgid "Please fill in all fields before submitting."
-msgstr "Rellene todos los campos antes de enviar el formulario."
-
-#: templates/cronjobs.html:710
-msgid "Minute"
-msgstr "Minuto"
-
-#: templates/cronjobs.html:711
-msgid "Hour"
-msgstr "Hora"
-
-#: templates/cronjobs.html:712
-msgid "Day"
-msgstr "Día"
-
-#: templates/cronjobs.html:713
-msgid "Month"
-msgstr "Mes"
-
-#: templates/cronjobs.html:714
-msgid "Weekday"
-msgstr "Día de la semana"
-
-#: templates/cronjobs.html:715 templates/processlist.html:17
-msgid "Command"
-msgstr "Día"
-
-#: templates/cronjobs.html:733 templates/filemanager.html:329
-msgid "Edit"
-msgstr "Editar"
-
-#: templates/cronjobs.html:734 templates/domains/domains.html:454
-#: templates/filemanager.html:314 templates/filemanager.html:2001
-#: templates/filemanager.html:2028 templates/pm2.html:244
-#: templates/ssl.html:194
-msgid "Delete"
-msgstr "Eliminar"
-
-#: templates/cronjobs.html:751
-msgid "Edit Cron Job"
-msgstr "Editar Cron Job"
-
-#: templates/cronjobs.html:752 templates/cronjobs.html:759
-#: templates/databases.html:300 templates/domains/domains.html:443
-#: templates/domains/edit_dns_zone.html:246 templates/filemanager.html:1971
-#: templates/ftp.html:53 templates/ftp.html:94 templates/ftp.html:107
-#: templates/php.html:22 templates/ssl.html:66 templates/websites.html:2154
-msgid "Close"
-msgstr "Cerrar"
-
-#: templates/cronjobs.html:760
-msgid "Save changes"
-msgstr "Guardar cambios"
-
-#: templates/cronjobs.html:771 templates/filemanager.html:1991
-msgid "Confirm Deletion"
-msgstr "Confirmar borrado"
-
-#: templates/cronjobs.html:775
-msgid "Are you sure you want to delete the following cron job?"
-msgstr "Está seguro de que desea eliminar el siguiente cron job?"
-
-#: templates/cronjobs.html:780
-msgid "Confirm Delete"
-msgstr "Confirmar borrado"
-
-#: templates/cronjobs.html:823
-msgid "Error editing cron job."
-msgstr "Error al editar cron job."
-
-#: templates/cronjobs.html:827
-msgid "AJAX error while editing cron job."
-msgstr "Error AJAX al editar el cron job."
-
-#: templates/cronjobs.html:849
-msgid "Error deleting cron job."
-msgstr "Error al borrar el cron job."
-
-#: templates/cronjobs.html:853
-msgid "AJAX error while deleting cron job."
-msgstr "Error AJAX al borrar el cron job."
-
-#: templates/cronjobs.html:866
-msgid "No cronjobs."
-msgstr "No hay Cron Jobs."
-
-#: templates/cronjobs.html:876
-msgid "Create CronJob"
-msgstr "Crear Cron Job"
-
-#: templates/databases.html:26 templates/databases.html:375
-msgid "Database Wizard"
-msgstr "Asistente de bases de datos"
-
-#: templates/databases.html:33 templates/databases.html:196
-#: templates/databases.html:390
-msgid "Database Name"
-msgstr "Nombre de la base de datos"
-
-#: templates/databases.html:38
-msgid "Random Database Name"
-msgstr "Nombre de base de datos aleatorio"
-
-#: templates/databases.html:41 templates/databases.html:53
-#: templates/databases.html:63
-msgid "Generate Random"
-msgstr "Generar aleatorio"
-
-#: templates/databases.html:45 templates/databases.html:225
-#: templates/databases.html:268 templates/databases.html:346
-#: templates/ftp.html:69 templates/user/login.html:36
-msgid "Username"
-msgstr "Nombre de usuario"
-
-#: templates/databases.html:50
-msgid "Random Username"
-msgstr "Nombre de usuario aleatorio"
-
-#: templates/databases.html:58 templates/databases.html:352
-#: templates/ftp.html:73 templates/user/login.html:41
-msgid "Password"
-msgstr "Contraseña"
-
-#: templates/databases.html:60
-msgid "Random Password"
-msgstr "Contraseña aleatoria"
-
-#: templates/databases.html:69
-msgid "Create Database, User, and Grant All Privileges"
-msgstr "Crear base de datos, usuario y otorgar todos los privilegios"
-
-#: templates/databases.html:81
-msgid "Success!"
-msgstr "Exitoso!"
-
-#: templates/databases.html:86
-msgid "Database Name:"
-msgstr "Nombre de base de datos:"
-
-#: templates/databases.html:87 templates/databases.html:341
-#: templates/ssh.html:136 templates/user/account.html:53
-#: templates/websites.html:1287
-msgid "Username:"
-msgstr "Nombre de usuario:"
-
-#: templates/databases.html:88 templates/databases.html:350
-#: templates/ssh.html:140 templates/websites.html:1289
-msgid "Password:"
-msgstr "Contraseña:"
-
-#: templates/databases.html:187
-msgid "Create Database"
-msgstr "Crear base de datos"
-
-#: templates/databases.html:201 templates/databases.html:359
-#: templates/pm2.html:182
-msgid "Create"
-msgstr "Crear"
-
-#: templates/databases.html:215
-msgid "Assign user to existing MySQL database"
-msgstr "Asignar usuario a base de datos MySQL existente"
-
-#: templates/databases.html:222 templates/databases.html:264
-msgid "Select user:"
-msgstr "Seleccionar usuario:"
-
-#: templates/databases.html:229 templates/databases.html:272
-msgid "Select database:"
-msgstr "Seleccionar base de datos:"
-
-#: templates/databases.html:232 templates/databases.html:348
-#: templates/processlist.html:15
-msgid "Host"
-msgstr "Host"
-
-#: templates/databases.html:235 templates/databases.html:278
-#: templates/websites.html:1280
-msgid "Database"
-msgstr "Base de datos"
-
-#: templates/databases.html:242 templates/databases.html:410
-msgid "Assign"
-msgstr "Asignar"
-
-#: templates/databases.html:255
-msgid "Remove user access from database"
-msgstr "Remover acceso de usuario de la base de datos"
-
-#: templates/databases.html:285
-msgid "Remove Privileges"
-msgstr "Remover privilegios"
-
-#: templates/databases.html:299 templates/databases.html:318
-#: templates/ssh.html:176
-msgid "Change Password"
-msgstr "Cambiar contraseña"
-
-#: templates/databases.html:306
-msgid "Change password for MySQL database user"
-msgstr "Cambiar contraseña de usuario de base de datos MySQL"
-
-#: templates/databases.html:307 templates/databases.html:308
-msgid "Database User"
-msgstr "Usuario de base de datos"
-
-#: templates/databases.html:311 templates/databases.html:312
-msgid "New Password"
-msgstr "Nueva contraseña"
-
-#: templates/databases.html:332
-msgid "Create new MySQL user"
-msgstr "Crear nuevo usuario MySQL"
-
-#: templates/databases.html:371
-msgid "New DB"
-msgstr "Nueva BD"
-
-#: templates/databases.html:371
-msgid "New Database"
-msgstr "Nueva base de datos"
-
-#: templates/databases.html:375
-msgid "Wizard"
-msgstr "Asistente"
-
-#: templates/databases.html:384
+#: templates/flarum.html:357 templates/flarum.html:484
+#: templates/manager/mautic.html:480 templates/manager/wordpress.html:1971
+#: templates/mautic.html:124 templates/mautic.html:187
+#: templates/wordpress.html:130 templates/wordpress.html:193
+msgid "Uninstall"
+msgstr ""
+
+#: templates/flarum.html:361 templates/flarum.html:488
+msgid "Remove from the Manager"
+msgstr ""
+
+#: templates/flarum.html:362 templates/flarum.html:489
 msgid ""
-"MySQL databases are used to store and manage your website's data, such as "
-"content, user information, and product details, making it accessible and "
-"organized for your web applications. On this page, you can easily create new "
-"databases and efficiently manage existing ones to organize and store your "
-"website's data effectively."
+"This will just remove the installation from the Manager but keep the files "
+"and database."
 msgstr ""
-"Las bases de datos MySQL se utilizan para almacenar y gestionar los datos de "
-"su sitio web, como el contenido, la información del usuario y los detalles "
-"del producto, haciéndolos accesibles y organizados para sus aplicaciones "
-"web. En esta página, puede crear fácilmente nuevas bases de datos y "
-"gestionar eficientemente las existentes para organizar y almacenar los datos "
-"de su sitio web de manera eficaz."
 
-#: templates/databases.html:391 templates/filemanager.html:364
-msgid "Size"
-msgstr "Tamaño"
+#: templates/flarum.html:363 templates/flarum.html:490
+#: templates/manager/mautic.html:430 templates/manager/websitebuilder.html:181
+#: templates/manager/wordpress.html:1921 templates/mautic.html:121
+#: templates/mautic.html:184 templates/wordpress.html:127
+#: templates/wordpress.html:190
+msgid "Detach"
+msgstr ""
 
-#: templates/databases.html:392
-msgid "Assigned Users"
-msgstr "Usuarios asignados"
+#: templates/flarum.html:384 templates/flarum.html:516
+#: templates/manager/sites.html:8 templates/mautic.html:112
+#: templates/wordpress.html:118
+msgid "Manage"
+msgstr ""
 
-#: templates/databases.html:405
-msgid "Users"
-msgstr "Usuarios"
-
-#: templates/databases.html:408 templates/partials/sidebar.html:39
-#: templates/php.html:47 templates/pm2.html:315
-msgid "New"
-msgstr "Nuevo"
-
-#: templates/databases.html:408 templates/databases.html:430
-#: templates/processlist.html:14
-msgid "User"
-msgstr "Usuario"
-
-#: templates/databases.html:410
-msgid "to Database"
-msgstr "a Base de datos"
-
-#: templates/databases.html:413 templates/websites.html:2183
-#: templates/wordpress.html:501
+#: templates/flarum.html:385 templates/manager/mautic.html:132
+#: templates/manager/mautic.html:161
+#: templates/manager/python_node_apps.html:128
+#: templates/manager/python_node_apps.html:163 templates/manager/ruby.html:139
+#: templates/manager/ruby.html:167 templates/manager/wordpress.html:144
+#: templates/manager/wordpress.html:216
 msgid "Remove"
-msgstr "Remover"
-
-#: templates/databases.html:413
-msgid "from database"
-msgstr "de Base de datos"
-
-#: templates/databases.html:426
-msgid ""
-"MySQL users are essential for controlling who can access and interact with "
-"your databases, ensuring data security and controlled access to your "
-"website's information. Here you can create and manage MySQL user accounts "
-"with specific permissions, ensuring secure access to your databases."
 msgstr ""
-"Los usuarios MySQL son esenciales para controlar quién puede acceder e "
-"interactuar con sus bases de datos, garantizando la seguridad de los datos y "
-"el acceso controlado a la información de su sitio web. Aquí puedes crear y "
-"gestionar cuentas de usuario MySQL con permisos específicos, garantizando un "
-"acceso seguro a tus bases de datos."
 
-#: templates/disk_usage.html:8
+#: templates/dashboard/dashboard.html:147 templates/flarum.html:526
+#: templates/flarum.html:687
+msgid "Flarum"
+msgstr ""
+
+#: templates/flarum.html:592
+msgid "An error occurred while removing Flarum."
+msgstr ""
+
+#: templates/flarum.html:613
+msgid "An error occurred while detaching Flarum."
+msgstr ""
+
+#: templates/flarum.html:641
+msgid "No Flarum Installations"
+msgstr ""
+
+#: templates/flarum.html:642
+msgid ""
+"There are no existing Flarum installations. You can install a new instance "
+"below."
+msgstr ""
+
+#: templates/flarum.html:659
+msgid "No Domains"
+msgstr ""
+
+#: templates/flarum.html:660
+msgid "Add a domain name first in order to install Flarum."
+msgstr ""
+
+#: templates/flarum.html:663
+msgid "Add a Domain Name"
+msgstr ""
+
+#: templates/flarum.html:683
+msgid "Refresh"
+msgstr ""
+
+#: templates/flarum.html:683
+msgid "Data"
+msgstr ""
+
+#: templates/flarum.html:687
+msgid "Install"
+msgstr ""
+
+#: templates/flarum.html:692
+msgid "Switch to List View - perfect for those with many Websites."
+msgstr ""
+
+#: templates/flarum.html:695
+msgid ""
+"Switch to Grid View - a visual representation of your Websites and their "
+"content."
+msgstr ""
+
+#: templates/mautic.html:10
+msgid "Manage Mautic websites"
+msgstr ""
+
+#: templates/mautic.html:12 templates/wordpress.html:12
+msgid "Total installations:"
+msgstr ""
+
+#: templates/mautic.html:19 templates/wordpress.html:19
+msgid "New Installation"
+msgstr ""
+
+#: templates/mautic.html:52 templates/wordpress.html:57
+msgid "Switch to Table view"
+msgstr ""
+
+#: templates/mautic.html:54 templates/wordpress.html:59
+msgid "Display websites in a table"
+msgstr ""
+
+#: templates/mautic.html:58 templates/wordpress.html:63
+msgid "Switch to Cards view"
+msgstr ""
+
+#: templates/mautic.html:60 templates/wordpress.html:65
+msgid "Display websites in a grid"
+msgstr ""
+
+#: templates/manager/sites.html:75 templates/manager/wordpress.html:1296
+#: templates/mautic.html:91 templates/system/server_info.html:134
+#: templates/wordpress.html:96
+msgid "Version"
+msgstr ""
+
+#: templates/mautic.html:196
+msgid "Mautic"
+msgstr ""
+
+#: templates/mautic.html:263
+msgid "An error occurred while removing Mautic."
+msgstr ""
+
+#: templates/mautic.html:272
+msgid "Mautic detach process started. Please wait."
+msgstr ""
+
+#: templates/mautic.html:281
+msgid "Mautic installation detached successfully."
+msgstr ""
+
+#: templates/mautic.html:284
+msgid "An error occurred while detaching Mautic. Please try again."
+msgstr ""
+
+#: templates/mautic.html:301
+msgid "No Mautic Installations"
+msgstr ""
+
+#: templates/mautic.html:303
+msgid "No Mautic sites managed via OpenPanel. Install a new Mautic site."
+msgstr ""
+
+#: templates/mautic.html:305 templates/wordpress.html:396
+msgid "View Documentation"
+msgstr ""
+
+#: templates/services.html:13
+msgid "Manage service and view real-time resource usage."
+msgstr ""
+
+#: templates/cache/_shared.html:15 templates/cache/_shared.html:61
+#: templates/cache/varnish.html:34 templates/cache/varnish.html:82
+#: templates/mysql/phpmyadmin.html:65 templates/mysql/remote_mysql.html:78
+#: templates/psql/pgadmin.html:65 templates/psql/remote_psql.html:76
+#: templates/services.html:21 templates/services.html:67
+msgid "Click to Disable"
+msgstr ""
+
+#: templates/cache/_shared.html:22 templates/cache/_shared.html:76
+#: templates/cache/varnish.html:41 templates/cache/varnish.html:97
+#: templates/dashboard/twofa.html:11 templates/mysql/phpmyadmin.html:80
+#: templates/mysql/remote_mysql.html:93 templates/psql/pgadmin.html:80
+#: templates/psql/remote_psql.html:91 templates/services.html:28
+#: templates/services.html:82
+msgid "Click to Enable"
+msgstr ""
+
+#: templates/cache/_shared.html:35 templates/cache/varnish.html:54
+#: templates/mysql/phpmyadmin.html:37 templates/psql/pgadmin.html:37
+#: templates/services.html:41
+msgid "Not currently enabled by Administrator."
+msgstr ""
+
+#: templates/cache/_shared.html:36 templates/cache/varnish.html:55
+#: templates/mysql/phpmyadmin.html:38 templates/psql/pgadmin.html:38
+#: templates/services.html:42
+msgid "Contact your hosting provider"
+msgstr ""
+
+#: templates/cache/_shared.html:45 templates/cache/varnish.html:66
+#: templates/cache/varnish.html:135 templates/docker/containers.html:72
+#: templates/domains/domains.html:92 templates/domains/domains.html:195
+#: templates/domains/logs.html:180 templates/domains/logs.html:222
+#: templates/domains/ssl.html:27 templates/manager/wordpress.html:1135
+#: templates/mysql/phpmyadmin.html:49 templates/mysql/remote_mysql.html:62
+#: templates/psql/pgadmin.html:49 templates/psql/remote_psql.html:60
+#: templates/services.html:51 templates/system/ssh.html:26
+#: templates/system/waf.html:58 templates/user/active_sessions.html:59
+msgid "Status"
+msgstr ""
+
+#: templates/cache/_shared.html:46 templates/cache/varnish.html:67
+#: templates/services.html:52
+msgid "Enable/disable the service."
+msgstr ""
+
+#: templates/cache/_shared.html:56 templates/cache/varnish.html:77
+#: templates/mysql/phpmyadmin.html:60 templates/mysql/remote_mysql.html:73
+#: templates/psql/pgadmin.html:60 templates/psql/remote_psql.html:71
+#: templates/services.html:62 templates/system/ssh.html:37
+msgid "Enabled"
+msgstr ""
+
+#: templates/cache/_shared.html:71 templates/cache/varnish.html:92
+#: templates/mysql/phpmyadmin.html:75 templates/mysql/remote_mysql.html:88
+#: templates/psql/pgadmin.html:75 templates/psql/remote_psql.html:86
+#: templates/services.html:77 templates/system/ssh.html:45
+msgid "Disabled"
+msgstr ""
+
+#: templates/cache/_shared.html:89 templates/cache/varnish.html:110
+#: templates/mysql/phpmyadmin.html:93 templates/mysql/remote_mysql.html:106
+#: templates/psql/pgadmin.html:93 templates/psql/remote_psql.html:104
+#: templates/services.html:95
+msgid "Click to Restart"
+msgstr ""
+
+#: templates/services.html:107
+msgid "Service"
+msgstr ""
+
+#: templates/services.html:108
+msgid "Name for accessing the service from other containers."
+msgstr ""
+
+#: templates/docker/container_form.html:67
+#: templates/files/filemanager/modals/rename.html:31
+#: templates/files/filemanager/rename.html:28
+#: templates/manager/pm2_install.html:95 templates/services.html:113
+msgid "Name:"
+msgstr ""
+
+#: templates/cache/_shared.html:129 templates/cache/varnish.html:197
+#: templates/manager/python_node_apps.html:182 templates/services.html:132
+#: templates/system/cronjobs.html:134 templates/system/process_manager.html:58
+msgid "Container"
+msgstr ""
+
+#: templates/cache/_shared.html:130 templates/cache/varnish.html:198
+#: templates/services.html:133
+msgid "Current real-time resource usage for the service."
+msgstr ""
+
+#: templates/cache/_shared.html:200 templates/cache/varnish.html:267
+#: templates/services.html:197
+msgid "Edit Container limits"
+msgstr ""
+
+#: templates/cache/_shared.html:217 templates/cache/varnish.html:280
+#: templates/services.html:215
+msgid "View service logs."
+msgstr ""
+
+#: templates/cache/_shared.html:244 templates/cache/varnish.html:286
+#: templates/services.html:221
+msgid "View service log"
+msgstr ""
+
+#: templates/services.html:268
+msgid "Manage Service"
+msgstr ""
+
+#: templates/services.html:269
+msgid "Select system service to manage."
+msgstr ""
+
+#: templates/docker/change_images.html:120 templates/docker/terminal.html:164
+#: templates/services.html:281
+msgid "Select service"
+msgstr ""
+
+#: templates/wordpress.html:10
+msgid "Manage WordPress websites"
+msgstr ""
+
+#: templates/wordpress.html:22
+msgid "Scan for Existing Installations"
+msgstr ""
+
+#: templates/user/stats.html:29 templates/wordpress.html:54
+msgid "Refresh Data"
+msgstr ""
+
+#: templates/manager/wordpress.html:36 templates/manager/wordpress.html:288
+#: templates/wordpress.html:117 templates/wordpress.html:210
+msgid "Login as Admin"
+msgstr ""
+
+#: templates/wordpress.html:202
+msgid "WordPress"
+msgstr ""
+
+#: templates/wordpress.html:271
+msgid "An error occurred while removing WordPress. Please try again."
+msgstr ""
+
+#: templates/manager/mautic.html:537 templates/manager/wordpress.html:2028
+#: templates/wordpress.html:280
+msgid "WordPress detach process started. Please wait."
+msgstr ""
+
+#: templates/manager/mautic.html:546 templates/manager/wordpress.html:2037
+#: templates/wordpress.html:289
+msgid "WordPress installation detached successfully."
+msgstr ""
+
+#: templates/manager/mautic.html:549 templates/manager/wordpress.html:2040
+#: templates/wordpress.html:292
+msgid "An error occurred while detaching WordPress. Please try again."
+msgstr ""
+
+#: templates/wordpress.html:392
+msgid "No WordPress Installations"
+msgstr ""
+
+#: templates/wordpress.html:394
+msgid ""
+"No WordPress sites managed via OpenPanel. Install a new WordPress site or "
+"scan to find existing installations."
+msgstr ""
+
+#: templates/wordpress.html:425
+msgid "Scanning started..."
+msgstr ""
+
+#: templates/wordpress.html:442
+msgid "No installations found."
+msgstr ""
+
+#: templates/wordpress.html:458
+msgid "Error occurred during scan. Try again."
+msgstr ""
+
+#: templates/wordpress.html:468
+msgid "Data refresh in progress... Please wait."
+msgstr ""
+
+#: templates/wordpress.html:478
+msgid "Refresh completed."
+msgstr ""
+
+#: templates/wordpress.html:485
+msgid "Error occurred during refresh."
+msgstr ""
+
+#: templates/cache/_shared.html:101
+msgid "TCP"
+msgstr ""
+
+#: templates/cache/_shared.html:102
+msgid "IP and Port for accessing the service."
+msgstr ""
+
+#: templates/cache/_shared.html:107 templates/mysql/phpmyadmin.html:181
+#: templates/mysql/remote_mysql.html:124 templates/mysql/remote_mysql.html:147
+#: templates/psql/pgadmin.html:165 templates/psql/remote_psql.html:122
+#: templates/psql/remote_psql.html:144 templates/system/ssh.html:68
+msgid "Server:"
+msgstr ""
+
+#: templates/cache/_shared.html:111 templates/manager/pm2_install.html:120
+#: templates/mysql/phpmyadmin.html:185 templates/mysql/remote_mysql.html:128
+#: templates/mysql/remote_mysql.html:151 templates/psql/pgadmin.html:169
+#: templates/psql/remote_psql.html:126 templates/psql/remote_psql.html:148
+#: templates/system/ssh.html:72
+msgid "Port:"
+msgstr ""
+
+#: templates/cache/varnish.html:15
+msgid ""
+"Varnish is a reverse caching proxy used as HTTP accelerator for content-"
+"heavy dynamic web sites as well as APIs."
+msgstr ""
+
+#: templates/cache/varnish.html:23
+msgid "Install Varnish"
+msgstr ""
+
+#: templates/cache/varnish.html:123
+msgid "Enable/disable Varnish cache per domain."
+msgstr ""
+
+#: templates/cache/varnish.html:132 templates/domains/domains.html:61
+#: templates/domains/domains.html:188 templates/system/waf.html:54
+msgid "Domain Name"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:77 templates/domains/ssl.html:184
+#: templates/files/filemanager.html:204 templates/manager/mautic.html:182
+#: templates/manager/python_node_apps.html:1033 templates/manager/ruby.html:589
+#: templates/manager/websitebuilder.html:358
+#: templates/manager/wordpress.html:237 templates/partials/_header.html:33
+msgid "Files"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:81
+msgid "Applications"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:82 templates/manager/wordpress.html:2121
+msgid "Cache"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:83 templates/emails/accounts.html:12
+#: templates/partials/_header.html:59
+msgid "Emails"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:85 templates/partials/_header.html:84
+msgid "Docker"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:86 templates/partials/_header.html:89
+msgid "Advanced"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:87 templates/partials/_header.html:94
+msgid "Account"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:93 templates/files/upload_file.html:10
+msgid "File Upload"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:94
+msgid "Download Files"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:95 templates/dashboard/usage.html:113
+#: templates/files/ftp.html:13
+msgid "FTP Accounts"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:96
+#: templates/files/ftp_connections.html:12
+msgid "FTP Connections"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:98 templates/files/backups.html:10
+#: templates/manager/mautic.html:131 templates/manager/mautic.html:154
+#: templates/manager/wordpress.html:143 templates/manager/wordpress.html:209
+#: templates/partials/_header.html:99
+msgid "Backups"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:100
+#: templates/files/clamav/scanner.html:14
+msgid "ClamAV Scanner"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:108
+msgid "Redirects"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:109 templates/domains/dns.html:722
+msgid "DNS Zone Editor"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:111
+msgid "Suspend Domain"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:112
+msgid "Unsuspend Domain"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:113
+msgid "Change Docroot"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:114
+msgid "Edit Virtual Hosts"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:116
+msgid "Raw Access Logs"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:122
+#: templates/dashboard/dashboard.html:134 templates/mysql/databases.html:137
+#: templates/mysql/wizard.html:8 templates/psql/databases.html:126
+#: templates/psql/wizard.html:8
+msgid "Database Wizard"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:123
+#: templates/dashboard/dashboard.html:135
+msgid "Import Database"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:124
+msgid "Open phpMyAdmin"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:125
+msgid "Manage phpMyAdmin"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:127
+#: templates/dashboard/dashboard.html:138
+msgid "Remote Access"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:128 templates/mysql/configuration.html:13
+msgid "MySQL Configuration"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:139 templates/psql/configuration.html:13
+msgid "PostgreSQL Configuration"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:143
+msgid "All Websites"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:144
+msgid "WP Manager"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:145
+#: templates/manager/websitebuilder_install.html:9
+msgid "Website Builder"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:159
+msgid "Email Accounts"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:160
+msgid "Webmail"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:161
+msgid "Address Importer"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:166
+msgid "Select PHP version"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:167
+msgid "Default Version"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:169
+msgid "PHP Options"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:176
+msgid "Terminal"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:179
+msgid "Change Image tag"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:180
+msgid "Change webserver"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:181
+msgid "Change MySQL Type"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:185 templates/partials/_header.html:49
+msgid "Services"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:186 templates/system/cronjobs.html:23
+msgid "Cron Jobs"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:187 templates/system/ssh.html:13
+msgid "SSH Access"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:188
+msgid "Web Terminal"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:192
+msgid "Change TimeZone"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:193
+msgid "Webserver Configuration"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:194
+msgid "WAF Settings"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:200 templates/user/account.html:13
+msgid "Email & Password"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:202 templates/user/notifications.html:11
+msgid "Email Notifications"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:205
+msgid "Favorite Pages"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:206
+msgid "Account Activity"
+msgstr ""
+
+#: templates/dashboard/dashboard.html:208
+msgid "Log out"
+msgstr ""
+
+#: templates/dashboard/howto.html:6
+msgid "General How-to"
+msgstr ""
+
+#: templates/dashboard/information.html:28 templates/domains/ssl.html:78
+#: templates/manager/ruby.html:180
+msgid "Information"
+msgstr ""
+
+#: templates/dashboard/information.html:34 templates/emails/info.html:34
+#: templates/emails/info.html:50 templates/emails/new.html:40
+#: templates/files/ftp.html:58 templates/files/ftp_new.html:31
+#: templates/mysql/mysql_user.html:27 templates/mysql/password.html:26
+#: templates/mysql/users.html:85 templates/psql/mysql_user.html:27
+#: templates/psql/password.html:26 templates/psql/psql_user.html:21
+#: templates/psql/users.html:85 templates/user/account.html:70
+#: templates/user/login.html:19
+msgid "Username"
+msgstr ""
+
+#: templates/dashboard/information.html:35
+msgid "Plan"
+msgstr ""
+
+#: templates/dashboard/information.html:56 templates/system/server_info.html:60
+#: templates/user/active_sessions.html:53 templates/user/activity.html:46
+msgid "IP Address"
+msgstr ""
+
+#: templates/dashboard/information.html:57
+msgid "Last Login IP Address"
+msgstr ""
+
+#: templates/dashboard/information.html:75
+msgid "/"
+msgstr ""
+
+#: templates/dashboard/information.html:85
+#: templates/system/server_info.html:157
+msgid "Nameservers"
+msgstr ""
+
+#: templates/dashboard/twofa.html:11 templates/user/twofa_settings.html:26
+msgid "Click to disable 2FA"
+msgstr ""
+
+#: templates/dashboard/twofa.html:13
+msgid "2FA is <b>{status}</b> for your account."
+msgstr ""
+
+#: templates/dashboard/twofa.html:21
+msgid "Enable 2FA"
+msgstr ""
+
+#: templates/dashboard/usage.html:8
+msgid "Usage"
+msgstr ""
+
+#: templates/dashboard/usage.html:90
+msgid "Email accounts"
+msgstr ""
+
+#: templates/dashboard/usage.html:136
+msgid "Storage"
+msgstr ""
+
+#: templates/dashboard/usage.html:167 templates/files/inodes.html:66
+msgid "Inodes"
+msgstr ""
+
+#: templates/dashboard/usage.html:198 templates/docker/containers.html:65
+msgid "CPU Usage"
+msgstr ""
+
+#: templates/dashboard/usage.html:205
+msgid "Displays the current CPU consumption of all running Docker containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:208
+msgid "Shows the combined CPU usage from all running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:210 templates/dashboard/usage.html:254
+msgid "Total allocated is:"
+msgstr ""
+
+#: templates/dashboard/usage.html:210
+msgid "Cores"
+msgstr ""
+
+#: templates/dashboard/usage.html:243 templates/docker/containers.html:68
+msgid "Memory Usage"
+msgstr ""
+
+#: templates/dashboard/usage.html:249
+msgid ""
+"Displays the current Memory consumption of all running Docker containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:252
+msgid "Shows the combined Memory usage from all running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:254
+msgid "GB"
+msgstr ""
+
+#: templates/dashboard/usage.html:295
+msgid "Displays total number of running Docker containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:298
+msgid "Shows the total number of running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:317 templates/user/history_usage.html:155
+#: templates/user/stats.html:95
+msgid "Block I/O"
+msgstr ""
+
+#: templates/dashboard/usage.html:323
+msgid "Displays total read/write on disk by all running Docker containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:326
+msgid "Shows the total disk read/write usage from all running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:345 templates/user/stats.html:93
+msgid "Network I/O"
+msgstr ""
+
+#: templates/dashboard/usage.html:351
+msgid ""
+"Displays total sent/received data on network interface by all running Docker "
+"containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:354
+msgid "Shows the total network sent/received bandwidth by running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:372 templates/user/stats.html:98
+msgid "PIDs"
+msgstr ""
+
+#: templates/dashboard/usage.html:378
+msgid ""
+"Displays the number of processes or threads created by all running Docker "
+"containers."
+msgstr ""
+
+#: templates/dashboard/usage.html:381
+msgid "Shows the number of processes created by all running services."
+msgstr ""
+
+#: templates/dashboard/usage.html:398
+msgid "Measured:"
+msgstr ""
+
+#: templates/dashboard/usage.html:422 templates/dashboard/usage.html:423
+#: templates/dashboard/usage.html:424 templates/dashboard/usage.html:425
+#: templates/manager/mautic.html:214 templates/manager/mautic.html:257
+#: templates/manager/python_node_apps.html:1071 templates/manager/ruby.html:628
+#: templates/manager/websitebuilder.html:414
+#: templates/manager/wordpress.html:332 templates/manager/wordpress.html:375
+msgid "Calculating.."
+msgstr ""
+
+#: templates/docker/change_images.html:13
+msgid "Change image tag for"
+msgstr ""
+
+#: templates/docker/change_images.html:14
+msgid "Select docker image tag from"
+msgstr ""
+
+#: templates/docker/change_images.html:44
+msgid "New image tag:"
+msgstr ""
+
+#: templates/docker/change_images.html:68
+msgid "Back to Images"
+msgstr ""
+
+#: templates/docker/change_images.html:74
+msgid "Change tag"
+msgstr ""
+
+#: templates/docker/change_images.html:97
+msgid "Change docker image tag"
+msgstr ""
+
+#: templates/docker/change_images.html:98
+msgid "Change docker images tag in order to use specific service versions."
+msgstr ""
+
+#: templates/docker/change_mysql.html:9
+msgid "Change mysql server for new databases."
+msgstr ""
+
+#: templates/docker/change_mysql.html:13
+#: templates/docker/change_webserver.html:18
+msgid "Current:"
+msgstr ""
+
+#: templates/docker/change_mysql.html:30
+msgid ""
+"The following conditions must be met in order to switch the mysql server:"
+msgstr ""
+
+#: templates/docker/change_mysql.html:32
+msgid "All existing databases and users must be removed."
+msgstr ""
+
+#: templates/docker/change_mysql.html:33
+msgid "container must be stopped before starting:"
+msgstr ""
+
+#: templates/docker/change_mysql.html:49
+#: templates/docker/container_form.html:220
+msgid "Back to Containers"
+msgstr ""
+
+#: templates/docker/change_mysql.html:57
+msgid "Switch to"
+msgstr ""
+
+#: templates/docker/change_webserver.html:10
+msgid "Change webserver for new domains to: "
+msgstr ""
+
+#: templates/docker/change_webserver.html:35
+msgid "The following conditions must be met in order to switch the web server:"
+msgstr ""
+
+#: templates/docker/change_webserver.html:37
+msgid "All existing domains must be removed."
+msgstr ""
+
+#: templates/docker/change_webserver.html:38
+msgid "container must be stopped before starting new webserver."
+msgstr ""
+
+#: templates/docker/change_webserver.html:60
+msgid "Switch"
+msgstr ""
+
+#: templates/docker/container_form.html:9
+msgid "Edit Service"
+msgstr ""
+
+#: templates/docker/container_form.html:9
+msgid "Add New Service"
+msgstr ""
+
+#: templates/docker/container_form.html:10
+msgid "Edit docker service."
+msgstr ""
+
+#: templates/docker/container_form.html:10
+msgid "Add a new docker service"
+msgstr ""
+
+#: templates/docker/container_form.html:18
+msgid "Experimental feature"
+msgstr ""
+
+#: templates/docker/container_form.html:18
+msgid ""
+"Adding containers is an experimental feature and should not be used in "
+"production."
+msgstr ""
+
+#: templates/docker/container_form.html:18
+msgid "Please share feedback"
+msgstr ""
+
+#: templates/docker/container_form.html:86
+msgid "Docker Image and Tag:"
+msgstr ""
+
+#: templates/docker/container_form.html:93
+msgid "Environment Variables (key:value, one per line, optional):"
+msgstr ""
+
+#: templates/docker/container_form.html:101
+msgid "CPU Limit (e.g., 0.5):"
+msgstr ""
+
+#: templates/docker/container_form.html:109
+msgid "Memory Limit (e.g., 0.5G):"
+msgstr ""
+
+#: templates/docker/container_form.html:124
+msgid "Volumes:"
+msgstr ""
+
+#: templates/docker/container_form.html:127
+msgid "Mount Docker socket"
+msgstr ""
+
+#: templates/docker/container_form.html:133
+msgid "Volume name"
+msgstr ""
+
+#: templates/docker/container_form.html:134
+msgid "Mount path inside container"
+msgstr ""
+
+#: templates/docker/container_form.html:148
+msgid "Add"
+msgstr ""
+
+#: templates/docker/container_form.html:186
+msgid "Networks:"
+msgstr ""
+
+#: templates/docker/container_form.html:200
+msgid "Healthcheck (YAML format, optional):"
+msgstr ""
+
+#: templates/docker/container_form.html:225
+#: templates/domains/capitalize.html:115 templates/domains/dns.html:175
+#: templates/domains/dns.html:420 templates/domains/domains.html:271
+#: templates/domains/domains.html:301 templates/files/edit_file.html:77
+#: templates/files/edit_json_file.html:69 templates/system/cronjobs.html:189
+msgid "Save"
+msgstr ""
+
+#: templates/docker/containers.html:9
+msgid "Running containers:"
+msgstr ""
+
+#: templates/docker/containers.html:13
+msgid "Total CPU:"
+msgstr ""
+
+#: templates/docker/containers.html:14
+msgid "Total Memory:"
+msgstr ""
+
+#: templates/docker/containers.html:45
+msgid "New Service"
+msgstr ""
+
+#: templates/docker/containers.html:61 templates/domains/dns.html:127
+#: templates/domains/dns.html:150 templates/files/filemanager.html:101
+#: templates/files/filemanager/table.html:6
+#: templates/files/filemanager/table_trash.html:6 templates/files/trash.html:53
+#: templates/manager/python_node_apps.html:183
+msgid "Name"
+msgstr ""
+
+#: templates/docker/containers.html:272
+msgid "Checking containers runtime metrics.."
+msgstr ""
+
+#: templates/docker/containers.html:288
+msgid "No container are currently running."
+msgstr ""
+
+#: templates/docker/containers.html:392
+msgid "Error fetching docker stats for containers."
+msgstr ""
+
+#: templates/docker/delete_confirm.html:12
+msgid "Delete container"
+msgstr ""
+
+#: templates/docker/delete_confirm.html:13
+msgid "Deleting the container will remove the service and image."
+msgstr ""
+
+#: templates/docker/delete_confirm.html:30
+msgid "Are you sure you want to permanently delete the service"
+msgstr ""
+
+#: templates/docker/delete_confirm.html:31
+msgid "This will:"
+msgstr ""
+
+#: templates/docker/delete_confirm.html:35
+msgid "Stop and remove the running container."
+msgstr ""
+
+#: templates/docker/delete_confirm.html:36
+msgid "Delete the docker image and files."
+msgstr ""
+
+#: templates/docker/delete_confirm.html:50 templates/domains/dns.html:177
+#: templates/domains/dns.html:422 templates/domains/domains.html:273
+#: templates/domains/domains.html:303 templates/emails/delete.html:33
+#: templates/manager/mautic.html:461 templates/manager/mautic.html:511
+#: templates/manager/python_node_apps.html:781
+#: templates/manager/websitebuilder.html:212
+#: templates/manager/websitebuilder.html:262
+#: templates/manager/wordpress.html:634 templates/manager/wordpress.html:1952
+#: templates/manager/wordpress.html:2002
+msgid "Cancel"
+msgstr ""
+
+#: templates/docker/delete_confirm.html:53
+msgid "Delete Service"
+msgstr ""
+
+#: templates/docker/images.html:13
+msgid "Check for container image updates"
+msgstr ""
+
+#: templates/docker/images.html:17
+msgid "Last checked"
+msgstr ""
+
+#: templates/docker/images.html:17
+msgid "Never"
+msgstr ""
+
+#: templates/docker/images.html:133
+msgid "Image"
+msgstr ""
+
+#: templates/docker/images.html:134
+msgid "Tag"
+msgstr ""
+
+#: templates/docker/images.html:135 templates/files/ftp_password.html:182
+#: templates/files/ftp_path.html:67 templates/user/account.html:119
+msgid "Update"
+msgstr ""
+
+#: templates/docker/images.html:136 templates/mysql/processlist.html:74
+msgid "Info"
+msgstr ""
+
+#: templates/docker/images.html:222
+msgid "Check is in progress.."
+msgstr ""
+
+#: templates/docker/images.html:224
+msgid ""
+"This may take a few minutes to complete. Refresh the page to display data."
+msgstr ""
+
+#: templates/docker/terminal.html:15 templates/docker/terminal.html:151
+msgid "Docker Terminal"
+msgstr ""
+
+#: templates/docker/terminal.html:17
+msgid "Container:"
+msgstr ""
+
+#: templates/docker/terminal.html:152
+msgid "Select active service to open web terminal."
+msgstr ""
+
+#: templates/docker/volumes_TODO.html:10
+msgid "Total volumes:"
+msgstr ""
+
+#: templates/domains/capitalize.html:126 templates/domains/delete.html:85
+#: templates/domains/docroot.html:60 templates/domains/new.html:123
+#: templates/domains/redirect.html:68 templates/domains/ssl.html:16
+#: templates/domains/suspend.html:45 templates/domains/unsuspend.html:44
+msgid "Back to Domains"
+msgstr ""
+
+#: templates/domains/delete.html:12
+msgid "Delete domain"
+msgstr ""
+
+#: templates/domains/delete.html:13
+msgid ""
+"Deleting the domain name will stop any services associated with this domain "
+"from working, however all existing data such as emails and files will remain "
+"on disk."
+msgstr ""
+
+#: templates/domains/delete.html:34
+msgid "subdomains"
+msgstr ""
+
+#: templates/domains/delete.html:34 templates/domains/domains.html:229
+msgid "subdomain"
+msgstr ""
+
+#: templates/domains/delete.html:34 templates/domains/delete.html:41
+msgid "associated with this domain."
+msgstr ""
+
+#: templates/domains/delete.html:34
+msgid "Please remove the subdomains first in order to delete the domain name."
+msgstr ""
+
+#: templates/domains/delete.html:41
+msgid "websites"
+msgstr ""
+
+#: templates/domains/delete.html:41
+msgid "website"
+msgstr ""
+
+#: templates/domains/delete.html:41
+msgid "Please remove the websites first in order to delete the domain name."
+msgstr ""
+
+#: templates/domains/delete.html:42
+msgid "Websites that use this domain:"
+msgstr ""
+
+#: templates/domains/delete.html:59
+msgid "Folder"
+msgstr ""
+
+#: templates/domains/delete.html:59
+msgid "and all associated data will be kept."
+msgstr ""
+
+#: templates/domains/delete.html:61
+msgid ""
+"FTP accounts that have a path under this domain document root will remain."
+msgstr ""
+
+#: templates/domains/delete.html:63
+msgid "Websites that use this domain name will immediately stop working."
+msgstr ""
+
+#: templates/domains/delete.html:65
+msgid "All"
+msgstr ""
+
+#: templates/domains/delete.html:65
+msgid "email accounts will be deleted, but the messages remain on disk."
+msgstr ""
+
+#: templates/domains/delete.html:67
+msgid "DNS zone with all its records will be permanently deleted."
+msgstr ""
+
+#: templates/domains/delete.html:68
+msgid "SSL certificate for the domain will immediately be revoked."
+msgstr ""
+
+#: templates/domains/delete.html:89
+msgid "Delete Domain"
+msgstr ""
+
+#: templates/domains/dns.html:12
+msgid "Confirm DNS zone reset"
+msgstr ""
+
+#: templates/domains/dns.html:26
+msgid "Are you sure you want to reset the DNS zone for this domain?"
+msgstr ""
+
+#: templates/domains/dns.html:27
+msgid ""
+"This acton is irreversible and will delete all existing DNS records, then "
+"restore the default zone records."
+msgstr ""
+
+#: templates/domains/dns.html:33 templates/domains/dns.html:115
+#: templates/domains/dns.html:649
+msgid "Reset Zone"
+msgstr ""
+
+#: templates/domains/dns.html:47
+msgid "Edit DNS for"
+msgstr ""
+
+#: templates/domains/dns.html:48
+msgid "Total DNS records:"
+msgstr ""
+
+#: templates/domains/dns.html:85
+msgid "New Record"
+msgstr ""
+
+#: templates/domains/dns.html:99 templates/domains/dns.html:113
+msgid "Export Zone"
+msgstr ""
+
+#: templates/domains/dns.html:103 templates/domains/dns.html:637
+msgid "Reset"
+msgstr ""
+
+#: templates/domains/dns.html:130 templates/domains/dns.html:153
+msgid "TTL"
+msgstr ""
+
+#: templates/domains/dns.html:133 templates/domains/domains.html:81
+#: templates/domains/domains.html:192 templates/files/filemanager.html:174
+#: templates/files/filemanager/table.html:28
+#: templates/files/filemanager/table_trash.html:38
+#: templates/files/trash.html:151 templates/manager/sites.html:60
+msgid "Type"
+msgstr ""
+
+#: templates/domains/dns.html:136 templates/domains/dns.html:169
+msgid "Record"
+msgstr ""
+
+#: templates/domains/dns.html:157
+msgid "A"
+msgstr ""
+
+#: templates/domains/dns.html:158
+msgid "AAAA"
+msgstr ""
+
+#: templates/domains/dns.html:159
+msgid "CAA"
+msgstr ""
+
+#: templates/domains/dns.html:160
+msgid "CNAME"
+msgstr ""
+
+#: templates/domains/dns.html:161
+msgid "MX"
+msgstr ""
+
+#: templates/domains/dns.html:162
+msgid "SRV"
+msgstr ""
+
+#: templates/domains/dns.html:163
+msgid "TXT"
+msgstr ""
+
+#: templates/domains/dns.html:165
+msgid "IN"
+msgstr ""
+
+#: templates/domains/dns.html:168
+msgid "Priority"
+msgstr ""
+
+#: templates/domains/dns.html:190 templates/domains/dns.html:193
+msgid "Address"
+msgstr ""
+
+#: templates/domains/dns.html:280 templates/domains/dns.html:424
+msgid " Edit"
+msgstr ""
+
+#: templates/domains/dns.html:284
+msgid " Save"
+msgstr ""
+
+#: templates/domains/dns.html:286
+msgid " Cancel"
+msgstr ""
+
+#: templates/domains/dns.html:313
+#: templates/files/filemanager/permissions.html:39
+#: templates/user/twofa_settings.html:136
+msgid "Confirm"
+msgstr ""
+
+#: templates/domains/dns.html:322
+msgid " Delete"
+msgstr ""
+
+#: templates/domains/dns.html:333
+msgid "Deleting record, please wait."
+msgstr ""
+
+#: templates/domains/dns.html:345
+msgid "Record deleted successfully."
+msgstr ""
+
+#: templates/domains/dns.html:359
+msgid ""
+"Error occured deleting the record. Please refresh the page and try again. If "
+"the issue persists, try editing the zone file directly."
+msgstr ""
+
+#: templates/domains/dns.html:364
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: templates/domains/dns.html:449
+msgid "Edit Cancelled."
+msgstr ""
+
+#: templates/domains/dns.html:463
+msgid "Edit Cancelled. Relaoding the page."
+msgstr ""
+
+#: templates/domains/dns.html:531
+msgid "Record updated successfully."
+msgstr ""
+
+#: templates/domains/dns.html:614
+msgid "Edit DNS File for"
+msgstr ""
+
+#: templates/domains/dns.html:615 templates/domains/vhost.html:71
+msgid "Attention:"
+msgstr ""
+
+#: templates/domains/dns.html:615
+msgid ""
+"Editing DNS file is intended for advanced users only. This action can "
+"potentially lead to server misconfiguration or downtime if not done "
+"correctly."
+msgstr ""
+
+#: templates/domains/dns.html:615
+msgid ""
+"Please be cautious and make sure you understand the changes you are making."
+msgstr ""
+
+#: templates/domains/dns.html:619 templates/domains/vhost.html:29
+#: templates/mysql/configuration.html:36 templates/mysql/phpmyadmin.html:115
+#: templates/php/ini_editor.html:33 templates/php/options.html:37
+#: templates/psql/configuration.html:36 templates/psql/pgadmin.html:115
+#: templates/system/apache_nginx_conf_editor.html:26
+#: templates/system/cronjobs.html:47
+msgid "Save Changes"
+msgstr ""
+
+#: templates/domains/dns.html:629
+msgid "Table View"
+msgstr ""
+
+#: templates/domains/dns.html:633 templates/domains/dns.html:647
+msgid "Download File"
+msgstr ""
+
+#: templates/domains/dns.html:645
+msgid "Edit as Table"
+msgstr ""
+
+#: templates/domains/dns.html:680
+msgid "Saving zone file for domain"
+msgstr ""
+
+#: templates/domains/dns.html:680 templates/domains/new.html:279
+msgid "Please wait for the process to finish."
+msgstr ""
+
+#: templates/domains/dns.html:695
+msgid "Zone file saved successfully"
+msgstr ""
+
+#: templates/domains/dns.html:723
+msgid ""
+"Manage and edit Domain Name System (DNS) zone files, which contain critical "
+"information for mapping domain names to IP addresses and managing various "
+"DNS records, such as A, CNAME, MX, and TXT records."
+msgstr ""
+
+#: templates/domains/dns.html:744 templates/domains/docroot.html:100
+#: templates/domains/goaccess.html:33 templates/domains/logs.html:378
+#: templates/domains/redirect.html:110 templates/domains/ssl.html:336
+#: templates/domains/suspend.html:88 templates/domains/unsuspend.html:87
+#: templates/domains/vhost.html:89 templates/system/waf_logs.html:281
+msgid "Select domain"
+msgstr ""
+
+#: templates/domains/docroot.html:10
+msgid "Change docroot for"
+msgstr ""
+
+#: templates/domains/docroot.html:11 templates/domains/docroot.html:82
+msgid "Change docroot (directory) for domain"
+msgstr ""
+
+#: templates/domains/docroot.html:36 templates/domains/new.html:66
+msgid "Document Root (folder):"
+msgstr ""
+
+#: templates/domains/docroot.html:81
+msgid "Select Domain to change docroot"
+msgstr ""
+
+#: templates/domains/domains.html:15
+msgid "Total domains:"
+msgstr ""
+
+#: templates/domains/domains.html:51 templates/domains/logs.html:99
+#: templates/psql/processlist.html:70 templates/system/waf_logs.html:47
+msgid "Show Columns"
+msgstr ""
+
+#: templates/domains/domains.html:70 templates/domains/domains.html:190
+#: templates/user/favorites.html:54
+msgid "Link"
+msgstr ""
+
+#: templates/domains/domains.html:103 templates/domains/domains.html:198
+msgid "Document Root"
+msgstr ""
+
+#: templates/domains/domains.html:114 templates/domains/domains.html:201
+msgid "PHP Version"
+msgstr ""
+
+#: templates/domains/domains.html:137 templates/domains/domains.html:207
+msgid "Redirect"
+msgstr ""
+
+#: templates/domains/domains.html:149
+msgid "SSL Status"
+msgstr ""
+
+#: templates/domains/domains.html:177 templates/domains/new.html:13
+msgid "New Domain"
+msgstr ""
+
+#: templates/domains/domains.html:229
+msgid "domain"
+msgstr ""
+
+#: templates/domains/domains.html:233
+msgid "Suspended"
+msgstr ""
+
+#: templates/domains/domains.html:234
+#: templates/manager/python_node_apps.html:63
+msgid "Active"
+msgstr ""
+
+#: templates/domains/domains.html:297
+msgid "Enter redirect URL"
+msgstr ""
+
+#: templates/domains/domains.html:307
+msgid "Create Redirect"
+msgstr ""
+
+#: templates/domains/domains.html:321
+msgid "Automatic"
+msgstr ""
+
+#: templates/domains/domains.html:325
+msgid "Custom"
+msgstr ""
+
+#: templates/domains/domains.html:329
+msgid "None"
+msgstr ""
+
+#: templates/domains/domains.html:356
+msgid "No SSL is needed on the Tor network."
+msgstr ""
+
+#: templates/domains/domains.html:358
+msgid "Check"
+msgstr ""
+
+#: templates/domains/domains.html:387
+msgid "Manage WAF"
+msgstr ""
+
+#: templates/domains/domains.html:399
+msgid "Edit VirtualHosts"
+msgstr ""
+
+#: templates/domains/domains.html:405
+msgid "Capitalize"
+msgstr ""
+
+#: templates/domains/domains.html:423 templates/emails/delete.html:10
+#: templates/emails/single_account.html:34
+#: templates/files/filemanager/actions_buttons.html:18
+#: templates/files/filemanager/delete.html:41
+#: templates/files/filemanager/deleteTrash.html:26 templates/files/ftp.html:117
+#: templates/files/trash.html:36 templates/manager/python_node_apps.html:750
+#: templates/manager/ruby.html:328 templates/manager/websitebuilder.html:231
+#: templates/mysql/users.html:108 templates/psql/databases.html:173
+#: templates/psql/users.html:125
+msgid "Delete"
+msgstr ""
+
+#: templates/domains/domains.html:609
+msgid "Showing domains"
+msgstr ""
+
+#: templates/domains/domains.html:609 templates/mysql/users.html:72
+#: templates/psql/users.html:72
+msgid "to"
+msgstr ""
+
+#: templates/domains/domains.html:609
+msgid "from a total of"
+msgstr ""
+
+#: templates/domains/domains.html:614
+msgid "Page navigation"
+msgstr ""
+
+#: templates/domains/domains.html:618 templates/domains/domains.html:619
+#: templates/user/activity.html:95
+msgid "Previous"
+msgstr ""
+
+#: templates/domains/domains.html:640 templates/domains/domains.html:641
+#: templates/user/activity.html:105
+msgid "Next"
+msgstr ""
+
+#: templates/domains/goaccess.html:13
+msgid "View html reports generated from domain access logs."
+msgstr ""
+
+#: templates/domains/logs.html:12
+msgid "Domain Logs for"
+msgstr ""
+
+#: templates/domains/logs.html:13 templates/system/waf_logs.html:12
+msgid "Showing"
+msgstr ""
+
+#: templates/domains/logs.html:13 templates/system/waf_logs.html:12
+msgid "out of"
+msgstr ""
+
+#: templates/domains/logs.html:13 templates/domains/logs.html:20
+#: templates/system/waf_logs.html:12 templates/system/waf_logs.html:19
+msgid "rows"
+msgstr ""
+
+#: templates/domains/logs.html:20 templates/system/waf_logs.html:19
+msgid "Show all"
+msgstr ""
+
+#: templates/domains/logs.html:113 templates/domains/logs.html:215
+#: templates/user/activity.html:47
+msgid "Timestamp"
+msgstr ""
+
+#: templates/domains/logs.html:122 templates/domains/logs.html:216
+msgid "Level"
+msgstr ""
+
+#: templates/domains/logs.html:131 templates/domains/logs.html:217
+msgid "Logger"
+msgstr ""
+
+#: templates/domains/logs.html:140 templates/domains/logs.html:218
+msgid "Message"
+msgstr ""
+
+#: templates/domains/logs.html:149 templates/domains/logs.html:219
+msgid "Client IP"
+msgstr ""
+
+#: templates/domains/logs.html:160 templates/domains/logs.html:220
+msgid "Method"
+msgstr ""
+
+#: templates/domains/logs.html:170 templates/domains/logs.html:221
+msgid "URI"
+msgstr ""
+
+#: templates/domains/logs.html:189 templates/domains/logs.html:223
+#: templates/files/disk_usage.html:65 templates/files/filemanager.html:165
+#: templates/files/filemanager/table.html:7
+#: templates/files/filemanager/table_trash.html:7
+#: templates/files/trash.html:142 templates/mysql/databases.html:152
+#: templates/psql/databases.html:141
+msgid "Size"
+msgstr ""
+
+#: templates/domains/logs.html:198 templates/domains/logs.html:224
+msgid "Duration"
+msgstr ""
+
+#: templates/domains/logs.html:356
+msgid "Domain Logs"
+msgstr ""
+
+#: templates/domains/logs.html:357
+msgid "View webserver raw access logs for domains."
+msgstr ""
+
+#: templates/domains/new.html:14
+msgid "Add a new domain name to be used for websites, emails, etc."
+msgstr ""
+
+#: templates/domains/new.html:22
+msgid "Hide Details"
+msgstr ""
+
+#: templates/domains/new.html:22
+msgid "Show Details"
+msgstr ""
+
+#: templates/domains/new.html:80
+msgid ""
+"docroot module or feature are not enabled. Contact Administrator to change "
+"docroot."
+msgstr ""
+
+#: templates/domains/new.html:219
+msgid "Invalid domain name. Please enter a valid domain name like"
+msgstr ""
+
+#: templates/domains/new.html:219 templates/manager/mautic.html:389
+#: templates/manager/mautic.html:474 templates/manager/websitebuilder.html:140
+#: templates/manager/websitebuilder.html:225
+#: templates/manager/wordpress.html:1880 templates/manager/wordpress.html:1965
+msgid "or"
+msgstr ""
+
+#: templates/domains/new.html:239
+msgid ""
+"Paths for both public and secret files must be set for importing .onion "
+"domain."
+msgstr ""
+
+#: templates/domains/new.html:246
+msgid "Paths for both public and secret files must start with /var/www/html/."
+msgstr ""
+
+#: templates/domains/new.html:279
+msgid "Adding domain"
+msgstr ""
+
+#: templates/domains/new.html:290 templates/domains/new.html:356
+msgid "Error adding domain name"
+msgstr ""
+
+#: templates/domains/new.html:290 templates/emails/confirm_import.html:165
+msgid "Network response from backend was not ok. Please contact support."
+msgstr ""
+
+#: templates/domains/new.html:337
+msgid "Domain name"
+msgstr ""
+
+#: templates/domains/new.html:337
+msgid "added successfully."
+msgstr ""
+
+#: templates/domains/new.html:356
+msgid "Click on Show Details above to view the log."
+msgstr ""
+
+#: templates/domains/new.html:369
+msgid "Retry"
+msgstr ""
+
+#: templates/domains/new.html:441
+msgid "Converted to Punycode:"
+msgstr ""
+
+#: templates/domains/new.html:441
+msgid "(for compatibility with internationalized domain names)"
+msgstr ""
+
+#: templates/domains/redirect.html:13
+msgid "Edit Redirect for"
+msgstr ""
+
+#: templates/domains/redirect.html:13
+msgid "Create Redirect for"
+msgstr ""
+
+#: templates/domains/redirect.html:14
+msgid "Edit or delete URL redirect for domain"
+msgstr ""
+
+#: templates/domains/redirect.html:14
+msgid "Redirect domain to URL."
+msgstr ""
+
+#: templates/domains/redirect.html:30
+msgid "https://"
+msgstr ""
+
+#: templates/domains/redirect.html:44
+msgid "Save Redirect"
+msgstr ""
+
+#: templates/domains/redirect.html:57
+msgid "Delete Redirect"
+msgstr ""
+
+#: templates/domains/redirect.html:89
+msgid "Redirect Domain to URL"
+msgstr ""
+
+#: templates/domains/redirect.html:90
+msgid ""
+"Redirecting a domain will immediately redirect all traffic to the new URL, "
+"while Email and other services remain operational."
+msgstr ""
+
+#: templates/domains/ssl.html:11
+msgid "Configure SSL for"
+msgstr ""
+
+#: templates/domains/ssl.html:13
+msgid "Configure AutoSSL or upload a custom certificate for a domain."
+msgstr ""
+
+#: templates/domains/ssl.html:28
+msgid "Current SSL setting for domain."
+msgstr ""
+
+#: templates/domains/ssl.html:38
+msgid "Auto SSL"
+msgstr ""
+
+#: templates/domains/ssl.html:46
+msgid "Custom SSL"
+msgstr ""
+
+#: templates/domains/ssl.html:52
+msgid "Switch back to AutoSSL"
+msgstr ""
+
+#: templates/domains/ssl.html:66
+msgid "Try enabling AutoSSL"
+msgstr ""
+
+#: templates/domains/ssl.html:79
+msgid "View current certificate information."
+msgstr ""
+
+#: templates/domains/ssl.html:84
+msgid "Certificate Details:"
+msgstr ""
+
+#: templates/domains/ssl.html:139
+msgid "Valid"
+msgstr ""
+
+#: templates/domains/ssl.html:142
+msgid "Invalid"
+msgstr ""
+
+#: templates/domains/ssl.html:167
+msgid "No Certificate!"
+msgstr ""
+
+#: templates/domains/ssl.html:185
+msgid "View current certificate files."
+msgstr ""
+
+#: templates/domains/ssl.html:190
+msgid "Certificate Files:"
+msgstr ""
+
+#: templates/domains/ssl.html:199
+msgid "View Files"
+msgstr ""
+
+#: templates/domains/ssl.html:208
+msgid "No Files"
+msgstr ""
+
+#: templates/domains/ssl.html:225
+msgid "Configure custom SSL"
+msgstr ""
+
+#: templates/domains/ssl.html:226
+msgid "Insert paths to certificate files to be used for this domain."
+msgstr ""
+
+#: templates/domains/ssl.html:248
+msgid "Path to Certificate:"
+msgstr ""
+
+#: templates/domains/ssl.html:261
+msgid "Path to Certificate key:"
+msgstr ""
+
+#: templates/domains/ssl.html:287
+msgid "Configure Custom Certificate"
+msgstr ""
+
+#: templates/domains/ssl.html:317
+msgid "Select Domain to edit SSL"
+msgstr ""
+
+#: templates/domains/ssl.html:318
+msgid "View and change SSL settings for a domain."
+msgstr ""
+
+#: templates/domains/suspend.html:8
+msgid "Suspend domain"
+msgstr ""
+
+#: templates/domains/suspend.html:9 templates/domains/suspend.html:67
+msgid ""
+"Suspending the domain will immediately disable website access, while Email "
+"and other services remain operational."
+msgstr ""
+
+#: templates/domains/suspend.html:24
+msgid "Confirm suspend of domain:"
+msgstr ""
+
+#: templates/domains/suspend.html:49
+msgid "Confirm Suspend"
+msgstr ""
+
+#: templates/domains/suspend.html:66
+msgid "Select Domain to Suspend"
+msgstr ""
+
+#: templates/domains/unsuspend.html:9
+msgid "Unsuspend domain"
+msgstr ""
+
+#: templates/domains/unsuspend.html:10 templates/domains/unsuspend.html:66
+msgid "Unsuspending a domain will immediately restore access to the website."
+msgstr ""
+
+#: templates/domains/unsuspend.html:23
+msgid "Confirm unsuspend of domain:"
+msgstr ""
+
+#: templates/domains/unsuspend.html:48
+msgid "Confirm Unsuspend"
+msgstr ""
+
+#: templates/domains/unsuspend.html:65
+msgid "Select Domain to Unsuspend"
+msgstr ""
+
+#: templates/domains/vhost.html:24 templates/domains/vhost.html:25
+#: templates/domains/vhost.html:62
+#: templates/files/filemanager/actions_buttons.html:30
+#: templates/system/cronjobs.html:187
+msgid "Edit"
+msgstr ""
+
+#: templates/domains/vhost.html:24 templates/domains/vhost.html:62
+msgid "VirtualHosts File"
+msgstr ""
+
+#: templates/domains/vhost.html:25
+msgid "VirtualHosts file for the domain name"
+msgstr ""
+
+#: templates/domains/vhost.html:63
+msgid "Select domain name to edit"
+msgstr ""
+
+#: templates/domains/vhost.html:63
+msgid "VirtualHosts file for."
+msgstr ""
+
+#: templates/domains/vhost.html:71
+msgid ""
+"Editing the domain file is intended for advanced users only. This action can "
+"potentially lead to server misconfiguration or downtime if not done "
+"correctly."
+msgstr ""
+
+#: templates/domains/vhost.html:73
+msgid ""
+"Please be cautious and make sure you understand the changes you are making. "
+"We use a rollback mechanism to check for errors, and if any issues are "
+"detected, we will revert the changes. However, it's important to have a "
+"backup of your configurations before proceeding."
+msgstr ""
+
+#: templates/emails/accounts.html:13
+msgid "Total emails:"
+msgstr ""
+
+#: templates/emails/accounts.html:38
+msgid "New Email"
+msgstr ""
+
+#: templates/emails/accounts.html:55
+msgid "Account @ Domain"
+msgstr ""
+
+#: templates/emails/accounts.html:56
+msgid "Storage Used"
+msgstr ""
+
+#: templates/emails/accounts.html:137
+msgid "Webmail for "
+msgstr ""
+
+#: templates/emails/accounts.html:137
+msgid " opened in new window."
+msgstr ""
+
+#: templates/emails/confirm_import.html:7 templates/emails/import.html:7
+msgid "Import Emails"
+msgstr ""
+
+#: templates/emails/confirm_import.html:8 templates/emails/import.html:8
+msgid "Import email accounts from .xls or .csv files."
+msgstr ""
+
+#: templates/emails/confirm_import.html:22
+msgid "⚠️ The following addresses will be skipped:"
+msgstr ""
+
+#: templates/emails/confirm_import.html:27
+msgid "domain does not exist"
+msgstr ""
+
+#: templates/emails/confirm_import.html:28
+msgid "address already exists"
+msgstr ""
+
+#: templates/emails/confirm_import.html:40
+msgid "The following users will be imported:"
+msgstr ""
+
+#: templates/emails/confirm_import.html:44
+#: templates/user/reset_password/request_email.html:20
+msgid "Email"
+msgstr ""
+
+#: templates/emails/confirm_import.html:45 templates/emails/info.html:35
+#: templates/emails/info.html:51 templates/emails/new.html:124
+#: templates/emails/single_account.html:145 templates/files/ftp_new.html:56
+#: templates/mysql/mysql_user.html:52 templates/mysql/mysql_user.html:62
+#: templates/mysql/password.html:46 templates/mysql/root_password.html:50
+#: templates/mysql/wizard.html:73 templates/psql/mysql_user.html:40
+#: templates/psql/password.html:46 templates/psql/password.html:56
+#: templates/psql/psql_user.html:46 templates/psql/psql_user.html:56
+#: templates/psql/wizard.html:73 templates/user/account.html:78
+#: templates/user/login.html:23
+msgid "Password"
+msgstr ""
+
+#: templates/emails/confirm_import.html:46
+msgid "Quota"
+msgstr ""
+
+#: templates/emails/confirm_import.html:62
+msgid "No Accounts to Import"
+msgstr ""
+
+#: templates/emails/confirm_import.html:77
+msgid "Back to Upload"
+msgstr ""
+
+#: templates/emails/confirm_import.html:82
+msgid "Start Import"
+msgstr ""
+
+#: templates/emails/confirm_import.html:155
+msgid "Starting import. Please wait for the process to finish."
+msgstr ""
+
+#: templates/emails/confirm_import.html:198
+msgid "Import process completed."
+msgstr ""
+
+#: templates/emails/confirm_import.html:207
+msgid "Error occured during import."
+msgstr ""
+
+#: templates/emails/confirm_import.html:207
+msgid "Please check the output below."
+msgstr ""
+
+#: templates/emails/confirm_import.html:229
+msgid "A network error occurred. Please try again."
+msgstr ""
+
+#: templates/emails/delete.html:11
+msgid "Delete email account and all it's data."
+msgstr ""
+
+#: templates/emails/delete.html:21
+msgid ""
+"Click on the button below to permanently delete the account and all it's "
+"emails."
+msgstr ""
+
+#: templates/emails/delete.html:40 templates/manager/websitebuilder.html:255
+msgid "Confirm Delete"
+msgstr ""
+
+#: templates/emails/delete.html:79 templates/emails/filter.html:59
+msgid "Select Email"
+msgstr ""
+
+#: templates/emails/delete.html:80
+msgid "Select email address to delete."
+msgstr ""
+
+#: templates/emails/delete.html:96 templates/emails/filter.html:75
+msgid "Select address"
+msgstr ""
+
+#: templates/emails/filter.html:12
+msgid "Email Filters"
+msgstr ""
+
+#: templates/emails/filter.html:13
+msgid "Sieve filters for email"
+msgstr ""
+
+#: templates/emails/filter.html:28
+msgid "Current Filters"
+msgstr ""
+
+#: templates/emails/filter.html:41 templates/emails/import.html:42
+#: templates/emails/info.html:72 templates/emails/new.html:296
+#: templates/emails/single_account.html:270
+msgid "Back to Emails"
+msgstr ""
+
+#: templates/emails/filter.html:45
+msgid "Save Filter"
+msgstr ""
+
+#: templates/emails/filter.html:60
+msgid "Select email address to edit filters."
+msgstr ""
+
+#: templates/emails/import.html:21
+msgid "Upload File"
+msgstr ""
+
+#: templates/emails/import.html:25
+msgid "CSV, XLSX or XLS files only."
+msgstr ""
+
+#: templates/emails/import.html:46 templates/files/filemanager.html:83
+#: templates/files/upload_file.html:114
+msgid "Upload"
+msgstr ""
+
+#: templates/emails/info.html:10
+msgid "View email server information for account"
+msgstr ""
+
+#: templates/emails/info.html:14
+msgid ""
+"How to setup your email client\n"
+"        "
+msgstr ""
+
+#: templates/emails/info.html:32
+msgid "Secure SSL/TLS Settings"
+msgstr ""
+
+#: templates/emails/info.html:35 templates/emails/info.html:51
+msgid "Use the email account’s password."
+msgstr ""
+
+#: templates/emails/info.html:37 templates/emails/info.html:52
+msgid "Incoming Server"
+msgstr ""
+
+#: templates/emails/info.html:38 templates/emails/info.html:53
+msgid "IMAP Port"
+msgstr ""
+
+#: templates/emails/info.html:39 templates/emails/info.html:54
+msgid "POP3 Port"
+msgstr ""
+
+#: templates/emails/info.html:40 templates/emails/info.html:55
+msgid "Outgoing Server"
+msgstr ""
+
+#: templates/emails/info.html:41 templates/emails/info.html:56
+msgid "SMTP Port"
+msgstr ""
+
+#: templates/emails/info.html:44 templates/emails/info.html:58
+msgid "IMAP, POP3, and SMTP require authentication."
+msgstr ""
+
+#: templates/emails/info.html:48
+msgid "Non-SSL Settings"
+msgstr ""
+
+#: templates/emails/new.html:7
+msgid "Create an Email"
+msgstr ""
+
+#: templates/emails/new.html:8
+msgid "Create a new Email account."
+msgstr ""
+
+#: templates/emails/new.html:42
+msgid "info"
+msgstr ""
+
+#: templates/emails/new.html:114 templates/emails/single_account.html:135
+#: templates/files/ftp_new.html:46 templates/files/ftp_password.html:36
+#: templates/manager/mautic_install.html:149
+#: templates/manager/wordpress_install.html:217
+#: templates/mysql/mysql_user.html:42 templates/mysql/password.html:36
+#: templates/mysql/root_password.html:30 templates/mysql/wizard.html:59
+#: templates/psql/password.html:36 templates/psql/psql_user.html:36
+#: templates/psql/wizard.html:59
+msgid "Weak password"
+msgstr ""
+
+#: templates/emails/new.html:115 templates/emails/single_account.html:136
+#: templates/files/ftp_new.html:47 templates/files/ftp_password.html:37
+#: templates/manager/mautic_install.html:150
+#: templates/manager/wordpress_install.html:218
+#: templates/mysql/mysql_user.html:43 templates/mysql/password.html:37
+#: templates/mysql/root_password.html:31 templates/mysql/wizard.html:60
+#: templates/psql/password.html:37 templates/psql/psql_user.html:37
+#: templates/psql/wizard.html:60
+msgid "Medium strength password"
+msgstr ""
+
+#: templates/emails/new.html:116 templates/emails/single_account.html:137
+#: templates/files/ftp_new.html:48 templates/files/ftp_password.html:38
+#: templates/manager/mautic_install.html:151
+#: templates/manager/wordpress_install.html:219
+#: templates/mysql/mysql_user.html:44 templates/mysql/password.html:38
+#: templates/mysql/root_password.html:32 templates/mysql/wizard.html:61
+#: templates/psql/password.html:38 templates/psql/psql_user.html:38
+#: templates/psql/wizard.html:61
+msgid "Strong password"
+msgstr ""
+
+#: templates/emails/new.html:134 templates/emails/single_account.html:155
+#: templates/files/ftp_new.html:67 templates/files/ftp_password.html:46
+#: templates/mysql/password.html:56 templates/mysql/root_password.html:40
+#: templates/user/reset_password/set_new_password.html:21
+msgid "New Password"
+msgstr ""
+
+#: templates/emails/new.html:300
+msgid "Create Email"
+msgstr ""
+
+#: templates/emails/single_account.html:30
+msgid "Edit Email account"
+msgstr ""
+
+#: templates/emails/single_account.html:49 templates/user/account.html:62
+msgid "Email address"
+msgstr ""
+
+#: templates/emails/single_account.html:57
+msgid "Current Usage"
+msgstr ""
+
+#: templates/emails/single_account.html:68
+msgid "Allocated Storage Space"
+msgstr ""
+
+#: templates/emails/single_account.html:87
+msgid "Receiving Incoming Mail"
+msgstr ""
+
+#: templates/emails/single_account.html:95
+#: templates/emails/single_account.html:117
+msgid "Allow"
+msgstr ""
+
+#: templates/emails/single_account.html:109
+msgid "Sending Outgoing Mail"
+msgstr ""
+
+#: templates/emails/single_account.html:274
+msgid "Update Email Settings"
+msgstr ""
+
+#: templates/error_pages/500.html:7
+msgid "ID:"
+msgstr ""
+
+#: templates/files/backup_destinations.html:10
+msgid "Backup Destination"
+msgstr ""
+
+#: templates/files/backup_destinations.html:12
+msgid "Select a backup destination."
+msgstr ""
+
+#: templates/files/backup_destinations.html:17
+msgid "Current destination:"
+msgstr ""
+
+#: templates/files/backup_destinations.html:19
+msgid "No destination configured yet."
+msgstr ""
+
+#: templates/files/backup_settings.html:14
+msgid "Backup Settings"
+msgstr ""
+
+#: templates/files/backup_settings.html:15
+msgid "Configure backup options and schedule."
+msgstr ""
+
+#: templates/files/backup_settings.html:46
+msgid "settings"
+msgstr ""
+
+#: templates/files/backup_settings.html:47
+msgid "Configure custom domain for accessing panels."
+msgstr ""
+
+#: templates/files/backup_settings.html:77
+msgid "Backup settings"
+msgstr ""
+
+#: templates/files/backup_settings.html:78
+msgid "Configure schedule, retention, etc."
+msgstr ""
+
+#: templates/files/backups.html:12
+msgid "Manage backups."
+msgstr ""
+
+#: templates/files/disk_usage.html:15
 msgid ""
 "Disk usage is the amount of space that is used by the content of your sites, "
 "this includes databases, files, videos, images, emails and pages."
 msgstr ""
-"El uso del disco es la cantidad de espacio utilizado por el contenido de sus "
-"sitios, esto incluye bases de datos, archivos, vídeos, imágenes, correos "
-"electrónicos y páginas."
 
-#: templates/disk_usage.html:13
-msgid "Disk usage per directory"
-msgstr "Uso de disco por directorio"
-
-#: templates/disk_usage.html:29 templates/inodes.html:30
-msgid "Browse Directories"
-msgstr "Examinar directorios"
-
-#: templates/disk_usage.html:46 templates/inodes.html:48
-#: templates/inodes.html:132
-msgid "Up One Level"
-msgstr "Un nivel arriba"
-
-#: templates/disk_usage.html:73
-msgid "Calculating disk usage for "
-msgstr "Calculando uso de disco para "
-
-#: templates/disk_usage.html:200
-msgid "Calculating disk usage for parent directory.."
-msgstr "Calculando el uso de disco para el directorio padre..."
-
-#: templates/edit_file.html:11
-msgid "The specified file does not exist."
-msgstr "El archivo especificado no existe."
-
-#: templates/edit_file.html:87
-msgid "Show in folder"
-msgstr "Mostrar en carpeta"
-
-#: templates/edit_file.html:125
-msgid ""
-"Are you sure you want to close the file editor without saving your changes?"
+#: templates/files/disk_usage.html:25 templates/files/inodes.html:26
+msgid "Reload Data"
 msgstr ""
-"Está seguro de que desea cerrar el editor de archivos sin guardar los "
-"cambios?"
 
-#: templates/edit_mysql_config.html:21
-msgid "Saving and restarting MySQL to apply changes..."
-msgstr "Guardar y reiniciar MySQL para aplicar los cambios..."
-
-#: templates/edit_mysql_config.html:82
-msgid ""
-"This tool allows you to make changes to your MySQL configuration. "
-"Modifications made here will prompt a MySQL service restart."
-msgstr ""
-"Esta herramienta le permite realizar cambios en la configuración de MySQL. "
-"Las modificaciones realizadas aquí provocarán un reinicio del servicio MySQL."
-
-#: templates/edit_mysql_config.html:88
-msgid "MySQL Configuration Settings"
-msgstr "Ajustes de configuración MySQL"
-
-#: templates/edit_mysql_config.html:129
-msgid "Recommended values:"
-msgstr "Valores recomendados:"
-
-#: templates/edit_mysql_config.html:179
-msgid "MySQL status:"
-msgstr "Estado MySQL:"
-
-#: templates/edit_mysql_config.html:179 templates/remote_mysql.html:174
-#: templates/ssh.html:197
-msgid "Enabled"
-msgstr "Activado"
-
-#: templates/edit_mysql_config.html:179 templates/remote_mysql.html:108
-#: templates/remote_mysql.html:174 templates/ssh.html:197
-msgid "Disabled"
-msgstr "Desactivado"
-
-#: templates/elasticsearch.html:20
-msgid "Enabling Elasticsearch service.."
-msgstr "Activando el servicio Elasticsearch..."
-
-#: templates/elasticsearch.html:23
-msgid "Installing Elasticsearch service.. Please wait"
-msgstr "Instalando el servicio Elasticsearch… Por favor espere"
-
-#: templates/elasticsearch.html:26
-msgid "Disabling Elasticsearch service.."
-msgstr "Desactivando el servicio Elasticsearch..."
-
-#: templates/elasticsearch.html:124 templates/memcached.html:142
-#: templates/redis.html:142
-msgid "Connection Info"
-msgstr "Información de conexión"
-
-#: templates/elasticsearch.html:130 templates/memcached.html:148
-#: templates/redis.html:148 templates/remote_mysql.html:104
-#: templates/ssh.html:197
-msgid "status:"
-msgstr "estado:"
-
-#: templates/elasticsearch.html:131 templates/memcached.html:149
-#: templates/redis.html:149
-msgid "Active"
-msgstr "Activo"
-
-#: templates/elasticsearch.html:139
-msgid "Elasticsearch server:"
-msgstr "Servidor Elasticsearch:"
-
-#: templates/elasticsearch.html:141 templates/memcached.html:159
-#: templates/redis.html:159
-msgid "*or localhost"
-msgstr "*o localhost"
-
-#: templates/elasticsearch.html:149 templates/memcached.html:167
-#: templates/redis.html:167
-msgid "*Access to the servis is NOT available from other servers."
-msgstr "*El acceso al servicio NO está disponible desde otros servidores."
-
-#: templates/elasticsearch.html:154
-msgid "View Elasticsearch service Log"
-msgstr "Ver el registro del servicio Elasticsearch"
-
-#: templates/elasticsearch.html:161
-msgid "Elasticsearch Settings"
-msgstr "Ajustes de Elasticsearch"
-
-#: templates/elasticsearch.html:181
-msgid "Elasticsearch service logs"
-msgstr "Registros del servicio Elasticsearch"
-
-#: templates/elasticsearch.html:194
-msgid "Elasticsearch is not currently installed."
-msgstr "Elasticsearch no está instalado actualmente."
-
-#: templates/elasticsearch.html:195
-msgid "To install Elasticsearch click on the button bellow."
-msgstr "Para instalar Elasticsearch, haga clic en el botón de abajo."
-
-#: templates/elasticsearch.html:198
-msgid "INSTALL ELASTICSEARCH"
-msgstr "INSTALAR ELASTICSEARCH"
-
-#: templates/elasticsearch.html:204
-msgid "Elasticsearch is currently disabled."
-msgstr "Elasticsearch está actualmente desactivado."
-
-#: templates/elasticsearch.html:205
-msgid "To enable Elasticsearch click on the button bellow."
-msgstr "Para activar Elasticsearch, haga clic en el botón de abajo."
-
-#: templates/elasticsearch.html:208
-msgid "START ELASTICSEARCH"
-msgstr "INICIAR ELASTICSEARCH"
-
-#: templates/elasticsearch.html:215
-msgid "Elasticsearch service status is unknown."
-msgstr "Se desconoce el estado del servicio Elasticsearch."
-
-#: templates/elasticsearch.html:216
-msgid ""
-"Unable to determinate current elasticsearch servise status, try Start&Stop "
-"actions."
-msgstr ""
-"No se puede determinar el estado actual del servicio elasticsearch, pruebe "
-"las acciones Iniciar y Detener."
-
-#: templates/elasticsearch.html:216 templates/memcached.html:253
-#: templates/redis.html:254
-msgid "If the issue persists please contact support."
-msgstr ""
-"Si el problema persiste, póngase en contacto con el servicio de asistencia."
-
-#: templates/elasticsearch.html:219 templates/memcached.html:256
-#: templates/redis.html:257
-msgid "START"
-msgstr "INICIAR"
-
-#: templates/elasticsearch.html:223 templates/memcached.html:260
-#: templates/redis.html:261
-msgid "STOP"
-msgstr "PARAR"
-
-#: templates/elasticsearch.html:272 templates/elasticsearch.html:287
-msgid "Disable Elasticsearch"
-msgstr "Desactivar Elasticsearch"
-
-#: templates/elasticsearch.html:277 templates/elasticsearch.html:291
-msgid "Enable Elasticsearch"
-msgstr "Activar Elasticsearch"
-
-#: templates/elasticsearch.html:282
-msgid "Install Elasticsearch"
-msgstr "Instalar Elasticsearch"
-
-#: templates/filemanager.html:285
-msgid "No items found."
-msgstr "No se han encontrado elementos."
-
-#: templates/filemanager.html:286
-msgid "Start creating new folders or uploading a new file!"
-msgstr "Comience a crear nuevas carpetas o a cargar un nuevo archivo!"
-
-#: templates/filemanager.html:297
-msgid "Select all"
-msgstr "Seleccionar todo"
-
-#: templates/filemanager.html:304 templates/filemanager.html:2064
-msgid "Copy"
-msgstr "Copiar"
-
-#: templates/filemanager.html:309 templates/filemanager.html:2103
-msgid "Move"
-msgstr "Mover"
-
-#: templates/filemanager.html:319
-msgid "Download"
-msgstr "Descargar"
-
-#: templates/filemanager.html:324
-msgid "View"
-msgstr "Ver"
-
-#: templates/filemanager.html:334 templates/filemanager.html:1981
-msgid "Rename"
-msgstr "Renombrar"
-
-#: templates/filemanager.html:339 templates/filemanager.html:366
-msgid "Permissions"
-msgstr "Permisos"
-
-#: templates/filemanager.html:344 templates/filemanager.html:1849
-msgid "Compress"
-msgstr "Comprimir"
-
-#: templates/filemanager.html:349
-msgid "Extract"
-msgstr "Extraer"
-
-#: templates/domains/edit_dns_zone.html:114
-#: templates/domains/edit_dns_zone.html:125
-#: templates/domains/edit_dns_zone.html:251
-#: templates/domains/edit_dns_zone.html:252 templates/filemanager.html:363
-#: templates/ssl.html:126
-msgid "Name"
-msgstr "Nombre"
-
-#: templates/filemanager.html:365
-msgid "Last Modified"
-msgstr "Última modificación"
-
-#: templates/filemanager.html:365 templates/user/history_usage.html:69
-msgid "Date"
-msgstr "Fecha"
-
-#: templates/filemanager.html:395
-msgid "Calculate"
-msgstr "Calcular"
-
-#: templates/filemanager.html:1191
-msgid "Change permissions for"
-msgstr "Cambiar permisos para"
-
-#: templates/filemanager.html:1203
-msgid "Please enter a 3-digit numeric value for permissions."
-msgstr "Introduzca un valor numérico de 3 dígitos para los permisos."
-
-#: templates/filemanager.html:1532
-msgid ""
-"Warning: Deleting a directory will remove all its subdirectories and files."
-msgstr ""
-"Advertencia: Al borrar un directorio se eliminarán todos sus subdirectorios "
-"y archivos."
-
-#: templates/filemanager.html:1803
-msgid "Extract File"
-msgstr "Extraer archivos"
-
-#: templates/filemanager.html:1807
-msgid "Extract the following file:"
-msgstr "Extraer el siguiente archivo:"
-
-#: templates/filemanager.html:1809
-msgid "Please enter extraction path:"
-msgstr "Ingrese la ruta para la extracción:"
-
-#: templates/domains/edit_dns_zone.html:412 templates/filemanager.html:1819
-#: templates/user/twofa_settings.html:110
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: templates/filemanager.html:1829
-msgid "Compress Multiple Items"
-msgstr "Comprimir varios elementos"
-
-#: templates/filemanager.html:1833
-msgid "Confirm the compression of the following items:"
-msgstr "Confirme la compresión de los siguientes elementos:"
-
-#: templates/filemanager.html:1835
-msgid "Archive Name"
-msgstr "Nombre del archivo"
-
-#: templates/filemanager.html:1859
-msgid "Set permissions"
-msgstr "Establecer permisos"
-
-#: templates/filemanager.html:1873 templates/filemanager.html:1886
-#: templates/filemanager.html:1899
-msgid "Read"
-msgstr "Leer"
-
-#: templates/filemanager.html:1876 templates/filemanager.html:1889
-#: templates/filemanager.html:1902
-msgid "Write"
-msgstr "Escribir"
-
-#: templates/filemanager.html:1879 templates/filemanager.html:1892
-#: templates/filemanager.html:1905
-msgid "Execute"
-msgstr "Ejecutar"
-
-#: templates/filemanager.html:1913
-msgid "Enter new Permissions for item"
-msgstr "Introducir nuevos permisos para el elemento"
-
-#: templates/filemanager.html:1970
-msgid "Rename Item"
-msgstr "Renombrar elemento"
-
-#: templates/filemanager.html:1974
-msgid "Enter the new file name to rename the item:"
-msgstr "Introduzca el nuevo nombre de archivo para el elemento:"
-
-#: templates/filemanager.html:1976
-msgid "New Name"
-msgstr "Nombre nuevo"
-
-#: templates/filemanager.html:1977
-msgid "New file/folder name"
-msgstr "Nuevo nombre de archivo/carpeta"
-
-#: templates/filemanager.html:1995
-msgid "Are you sure you want to delete the following"
-msgstr "Está seguro de que desea eliminar este/a"
-
-#: templates/filemanager.html:2011
-msgid "Delete Items"
-msgstr "Borrar elementos"
-
-#: templates/filemanager.html:2015
-msgid "Confirm the deleting of the following items:"
-msgstr "Confirme la eliminación de los siguientes elementos:"
-
-#: templates/filemanager.html:2023
-msgid "Deleting..."
-msgstr "Eliminando..."
-
-#: templates/filemanager.html:2038
-msgid "Copy items"
-msgstr "Copiar elementos"
-
-#: templates/filemanager.html:2042
-msgid "Confirm the copy of the following items:"
-msgstr "Confirme la copia de los siguientes elementos:"
-
-#: templates/filemanager.html:2044 templates/filemanager.html:2082
-msgid "Destination path"
-msgstr "Ruta de destino"
-
-#: templates/filemanager.html:2058
-msgid "Copying..."
-msgstr "Copiando..."
-
-#: templates/filemanager.html:2075
-msgid "Move items"
-msgstr "Mover elementos"
-
-#: templates/filemanager.html:2080
-msgid "Confirm the moving of the following items:"
-msgstr "Confirme que desea mover los siguientes elementos:"
-
-#: templates/filemanager.html:2096
-msgid "Moving..."
-msgstr "Moviendo..."
-
-#: templates/filemanager.html:2113
-msgid "Create New File"
-msgstr "Crear nuevo archivo"
-
-#: templates/filemanager.html:2117
-msgid "File Name"
-msgstr "Nombre del archivo"
-
-#: templates/filemanager.html:2122
-msgid "Create File"
-msgstr "Crear archivo"
-
-#: templates/filemanager.html:2125
-msgid "New file will be created in:"
-msgstr "El nuevo archivo será creado en:"
-
-#: templates/filemanager.html:2136
-msgid "Create New Folder"
-msgstr "Crear nueva carpeta"
-
-#: templates/filemanager.html:2141
-msgid "Folder Name"
-msgstr "Nombre de la carpeta"
-
-#: templates/filemanager.html:2145
-msgid "Create Folder"
-msgstr "Crear carpeta"
-
-#: templates/filemanager.html:2149
-msgid "New folder be created in:"
-msgstr "La nueva carpeta será creada en:"
-
-#: templates/filemanager.html:2179
-msgid "Uploading..."
-msgstr "Subiendo..."
-
-#: templates/fix_permissions.html:4
-msgid "Fix and reset permissions for files and folders."
-msgstr "Corregir y restablecer los permisos de archivos y carpetas."
-
-#: templates/fix_permissions.html:8 templates/malware_scanner.html:12
-msgid "Choose a directory"
-msgstr "Seleccione un directorio"
-
-#: templates/fix_permissions.html:22
-msgid "Working..."
-msgstr "Trabajando..."
-
-#: templates/fix_permissions.html:30
-msgid "Permissions are fixed!"
-msgstr "Los permisos fueron corregidos!"
-
-#: templates/fix_permissions.html:61 templates/malware_scanner.html:102
-#: templates/process_manager.html:85
-msgid "Network response was not ok"
-msgstr "La respuesta de la red no fue correcta"
-
-#: templates/fix_permissions.html:77
-msgid "Fixing permissions failed"
-msgstr "La corrección de permisos ha fallado"
-
-#: templates/fix_permissions.html:84
-msgid "Complete"
-msgstr "Completo"
-
-#: templates/ftp.html:28
-msgid "Use your FTP account with an FTP client such as "
-msgstr "Utiliza tu cuenta FTP con un cliente FTP como "
-
-#: templates/ftp.html:28
-msgid "to transfer files to and from your website."
-msgstr "para transferir archivos hacia y desde su sitio web."
-
-#: templates/ftp.html:34
-msgid "Username (Login)"
-msgstr "Nombre de usuario (Login)"
-
-#: templates/ftp.html:35
-msgid "Path"
-msgstr "Ruta"
-
-#: templates/ftp.html:52
-msgid "Add FTP Account"
-msgstr "Agregar cuenta FTP"
-
-#: templates/ftp.html:77 templates/inodes.html:41
+#: templates/files/disk_usage.html:62 templates/files/inodes.html:63
 msgid "Directory"
-msgstr "Directorio"
+msgstr ""
 
-#: templates/ftp.html:95
-msgid "Create FTP Account"
-msgstr "Crear cuenta FTP"
+#: templates/files/disk_usage.html:77 templates/files/inodes.html:78
+#: templates/files/inodes.html:139
+msgid "Up One Level"
+msgstr ""
 
-#: templates/ftp.html:106
-msgid "Change FTP Password"
-msgstr "Cambiar contraseña de FTP"
+#: templates/files/disk_usage.html:213
+msgid "Calculating disk usage for parent directory.."
+msgstr ""
 
-#: templates/ftp.html:126
+#: templates/files/edit_file.html:11 templates/files/edit_file.html:73
+#: templates/files/edit_json_file.html:10
+#: templates/files/edit_json_file.html:65
+msgid "Edit File"
+msgstr ""
+
+#: templates/files/edit_file.html:21 templates/files/edit_json_file.html:20
+msgid "The specified file does not exist."
+msgstr ""
+
+#: templates/files/filemanager.html:73
+msgid "Search Files & Folders"
+msgstr ""
+
+#: templates/files/filemanager.html:77
+msgid "New File"
+msgstr ""
+
+#: templates/files/filemanager.html:80
+msgid "New Folder"
+msgstr ""
+
+#: templates/files/filemanager.html:111
+#: templates/files/filemanager/table.html:10
+#: templates/files/filemanager/table_trash.html:10
+#: templates/files/trash.html:88 templates/user/history_usage.html:149
+msgid "Date"
+msgstr ""
+
+#: templates/files/filemanager.html:120
+#: templates/files/filemanager/table.html:13
+#: templates/files/filemanager/table_trash.html:23
+#: templates/files/trash.html:97
+msgid "Owner"
+msgstr ""
+
+#: templates/files/filemanager.html:129
+#: templates/files/filemanager/table.html:16
+#: templates/files/filemanager/table_trash.html:26
+#: templates/files/trash.html:106
+msgid "Group"
+msgstr ""
+
+#: templates/files/filemanager.html:138
+#: templates/files/filemanager/table.html:20
+#: templates/files/filemanager/table_trash.html:30
+#: templates/files/trash.html:115
+msgid "Links"
+msgstr ""
+
+#: templates/files/filemanager.html:147 templates/files/trash.html:124
+msgid "Link Target"
+msgstr ""
+
+#: templates/files/filemanager.html:156
+#: templates/files/filemanager/actions_buttons.html:38
+#: templates/files/filemanager/table.html:33
+#: templates/files/filemanager/table_trash.html:43
+#: templates/files/trash.html:133
+msgid "Permissions"
+msgstr ""
+
+#: templates/files/filemanager.html:195
+msgid "in:"
+msgstr ""
+
+#: templates/files/filemanager.html:195
+msgid "all folders"
+msgstr ""
+
+#: templates/files/filemanager.html:213
+msgid "Folders"
+msgstr ""
+
+#: templates/files/filemanager.html:222
+msgid "Specific extension"
+msgstr ""
+
+#: templates/files/fix_permissions.html:14
+msgid "Fix and reset permissions for files and folders under"
+msgstr ""
+
+#: templates/files/clamav/scanner.html:36
+#: templates/files/fix_permissions.html:30
+msgid "Choose a directory:"
+msgstr ""
+
+#: templates/files/fix_permissions.html:58
+msgid "Working..."
+msgstr ""
+
+#: templates/files/fix_permissions.html:67
+msgid "Permissions are fixed!"
+msgstr ""
+
+#: templates/files/fix_permissions.html:86
+msgid ""
+"The process has started. This may take a few minutes depending on the number "
+"of files and folders in the specified path. Please wait."
+msgstr ""
+
+#: templates/files/clamav/scanner.html:137
+#: templates/files/fix_permissions.html:102
+msgid "Network response was not ok"
+msgstr ""
+
+#: templates/files/fix_permissions.html:115
+msgid "Fixing permissions failed"
+msgstr ""
+
+#: templates/files/fix_permissions.html:119
+msgid ""
+"Permissions successfully fixed for all files and subdirectories inside the "
+"directory"
+msgstr ""
+
+#: templates/files/ftp.html:14
+msgid "Total accounts:"
+msgstr ""
+
+#: templates/files/ftp.html:17
+msgid "FTP Server:"
+msgstr ""
+
+#: templates/files/ftp.html:17
+msgid "FTP Port:"
+msgstr ""
+
+#: templates/files/ftp.html:18
+msgid "View Connections"
+msgstr ""
+
+#: templates/files/ftp.html:45
+msgid "New Account"
+msgstr ""
+
+#: templates/files/ftp.html:61
+msgid "Path"
+msgstr ""
+
+#: templates/files/ftp.html:65 templates/system/process_manager.html:65
+msgid "UID"
+msgstr ""
+
+#: templates/files/ftp.html:69
+msgid "GID"
+msgstr ""
+
+#: templates/files/ftp.html:73
+msgid "Configuration"
+msgstr ""
+
+#: templates/files/ftp.html:112
+msgid "Change Path"
+msgstr ""
+
+#: templates/files/ftp_connections.html:13
+msgid "Current FTP sessions of all sub-accounts."
+msgstr ""
+
+#: templates/files/ftp_connections.html:17
+msgid "Back to Accounts"
+msgstr ""
+
+#: templates/files/ftp_new.html:11
+msgid "New FTP Account"
+msgstr ""
+
+#: templates/files/ftp_new.html:12
+msgid "Create a new FTP account."
+msgstr ""
+
+#: templates/files/ftp_new.html:65
+msgid ""
+"Password must be at least 8 characters, and include a lowercase letter, an "
+"uppercase letter, a number, and a special character."
+msgstr ""
+
+#: templates/files/ftp_new.html:180
+msgid "Path (folder)"
+msgstr ""
+
+#: templates/files/ftp_new.html:199
+msgid "Back to FTP Accounts"
+msgstr ""
+
+#: templates/files/ftp_password.html:13
+msgid "FTP Password"
+msgstr ""
+
+#: templates/files/ftp_password.html:14
+msgid "Change FTP password for user"
+msgstr ""
+
+#: templates/files/ftp_password.html:56
 msgid "New password"
-msgstr "Nueva contraseña"
+msgstr ""
 
-#: templates/ftp.html:133
-msgid "Change FTP password"
-msgstr "Cambiar contraseña de FTP"
+#: templates/files/ftp_password.html:166 templates/user/account.html:97
+#: templates/user/reset_password/set_new_password.html:34
+msgid "Confirm Password"
+msgstr ""
 
-#: templates/ftp.html:144
-msgid "Change FTP Path"
-msgstr "Cambiar ruta de FTP"
+#: templates/files/ftp_path.html:12
+msgid "FTP Path"
+msgstr ""
 
-#: templates/ftp.html:164
-msgid "New path"
-msgstr "Nueva ruta"
+#: templates/files/ftp_path.html:13
+msgid "Change FTP path for user"
+msgstr ""
 
-#: templates/ftp.html:176
-msgid "Change FTP path"
-msgstr "Cambiar ruta de FTP"
+#: templates/files/ftp_path.html:31
+msgid "New Path"
+msgstr ""
 
-#: templates/inodes.html:8
+#: templates/files/ftp_path.html:37
+msgid "Path must be under"
+msgstr ""
+
+#: templates/files/inodes.html:15
 msgid ""
 "An inode is a data structure that keeps the information about a file on your "
 "hosting account. The number of inodes indicates the number of files and "
-"folders you have. This includes everything on your account, emails, files, "
-"folders, and anything you store on the server."
+"folders you have."
 msgstr ""
-"Un inode es una estructura de datos que guarda la información sobre un "
-"archivo en tu cuenta de hosting. El número de inodes indica el número de "
-"archivos y carpetas que tiene. Esto incluye todo en su cuenta, correos "
-"electrónicos, archivos, carpetas y cualquier cosa que almacene en el "
-"servidor."
 
-#: templates/inodes.html:14
-msgid "Inodes usage per directory"
-msgstr "Uso de inodes por directorio"
+#: templates/files/inodes.html:16
+msgid ""
+"This includes everything on your account, emails, files, folders, and "
+"anything you store on the server."
+msgstr ""
 
-#: templates/inodes.html:42
-msgid "Inodes"
-msgstr "Inodes"
-
-#: templates/inodes.html:76
-msgid "Calculating inodes count for"
-msgstr "Calculando cantidad de inodes para"
-
-#: templates/inodes.html:154
+#: templates/files/inodes.html:161
 msgid "Inodes Usage"
-msgstr "Uso de inodes"
+msgstr ""
 
-#: templates/inodes.html:171
-msgid "Calculating inodes for parent directory.."
-msgstr "Calculando inodes para directorio padre..."
+#: templates/files/inodes.html:178
+msgid "Calculating inodes count for parent directory.."
+msgstr ""
 
-#: templates/inodes.html:186
+#: templates/files/inodes.html:189
 msgid "Failed to fetch"
-msgstr "Error en la búsqueda"
-
-#: templates/domains/domains.html:479 templates/ip_blocker.html:64
-#: templates/ssl.html:78 templates/system/modsecurity.html:64
-msgid "Search domains"
-msgstr "Buscar dominios"
-
-#: templates/domains/domains.html:671 templates/domains/edit_dns_zone.html:174
-#: templates/domains/edit_dns_zone.html:309 templates/ip_blocker.html:113
-#: templates/php.html:64 templates/sites.html:147 templates/ssl.html:134
-#: templates/system/modsecurity.html:113 templates/wordpress.html:453
-msgid "Domain"
-msgstr "Dominio"
-
-#: templates/ip_blocker.html:114
-msgid "Blocked IPs"
-msgstr "IPs bloqueadas"
-
-#: templates/domains/domains.html:241 templates/domains/domains.html:266
-#: templates/ip_blocker.html:131 templates/memcached.html:207
-#: templates/redis.html:207
-msgid "Save"
-msgstr "Guardar"
-
-#: templates/ip_blocker.html:149 templates/ssl.html:350
-#: templates/system/modsecurity.html:204 templates/wordpress.html:792
-msgid "No Domains"
-msgstr "No hay dominios"
-
-#: templates/ip_blocker.html:151 templates/ssl.html:353
-#: templates/system/modsecurity.html:206 templates/wordpress.html:795
-msgid "Add a Domain Name"
-msgstr "Agregar un dominio"
-
-#: templates/logs.html:8
-msgid ""
-"Several actions are carried out by OpenPanel when the server is started; you "
-"may check their status and look for any potentional issues here."
 msgstr ""
-"OpenPanel lleva a cabo varias acciones cuando se inicia el servidor; puede "
-"comprobar su estado y buscar posibles problemas aquí."
 
-#: templates/malware_scanner.html:6
-msgid ""
-"The Clam AntiVirus Scanner (ClamAV) antivirus software searches your files "
-"for malicious programs. If the scanner identifies a potential security "
-"threat, it flags the file to allow you to take the appropriate action."
+#: templates/files/filemanager/action_buttons_trash.html:6
+#: templates/files/filemanager/actions_buttons.html:6
+#: templates/files/filemanager/inline_js_todo.html:87
+#: templates/files/filemanager/inline_js_todo.html:144
+#: templates/files/filemanager/inline_js_todo.html:231
+#: templates/files/filemanager/inline_js_todo.html:324
+#: templates/files/filemanager/inline_js_trash.html:269
+#: templates/files/filemanager/inline_js_trash.html:326
+#: templates/files/filemanager/inline_js_trash.html:413
+#: templates/files/filemanager/inline_js_trash.html:506
+#: templates/files/trash.html:23
+msgid "Select all"
 msgstr ""
-"El software antivirus Clam AntiVirus Scanner (ClamAV) busca programas "
-"maliciosos en tus archivos. Si el escáner identifica una amenaza potencial "
-"para la seguridad, marca el archivo para que puedas tomar las medidas "
-"oportunas."
 
-#: templates/malware_scanner.html:21
+#: templates/files/filemanager/restoreAll.html:28 templates/files/trash.html:27
+msgid "Restore All"
+msgstr ""
+
+#: templates/files/filemanager/action_buttons_trash.html:10
+#: templates/files/filemanager/restore.html:26 templates/files/trash.html:30
+msgid "Restore"
+msgstr ""
+
+#: templates/files/filemanager/deleteAll.html:28 templates/files/trash.html:33
+msgid "Delete All"
+msgstr ""
+
+#: templates/files/filemanager/table_trash.html:14
+#: templates/files/trash.html:64
+msgid "Deletion Date"
+msgstr ""
+
+#: templates/files/filemanager/table_trash.html:19
+#: templates/files/trash.html:75
+msgid "Original Path"
+msgstr ""
+
+#: templates/files/upload_file.html:10
+msgid "Download from URL"
+msgstr ""
+
+#: templates/files/upload_file.html:110
+msgid "Download from URL instead"
+msgstr ""
+
+#: templates/files/upload_file.html:146
+msgid "Upload from device instead"
+msgstr ""
+
+#: templates/files/filemanager/actions_buttons.html:22
+#: templates/files/upload_file.html:150
+msgid "Download"
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:13
+msgid "Quarantine"
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:17
+msgid "Quarantined files:"
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:21
+msgid ""
+"Files that were detected by ClamAV as malicious and placed in quarantine."
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:45
+msgid "Run Scan"
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:58
+msgid "No quarantined files"
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:59
+msgid ""
+"No malicious files have been detected or the scan has not been initiated yet."
+msgstr ""
+
+#: templates/files/clamav/quarantine.html:71
+msgid "File"
+msgstr ""
+
+#: templates/files/clamav/scanner.html:15
+msgid ""
+"Scan files for malicious programs with the Clam AntiVirus Scanner (ClamAV) "
+"antivirus software."
+msgstr ""
+
+#: templates/files/clamav/scanner.html:20
+msgid "View Quarantine"
+msgstr ""
+
+#: templates/files/clamav/scanner.html:55
 msgid "Start Scan"
-msgstr "Iniciar escaneo"
+msgstr ""
 
-#: templates/malware_scanner.html:26
+#: templates/files/clamav/scanner.html:64
 msgid "Scanning..."
-msgstr "Escaneando..."
+msgstr ""
 
-#: templates/malware_scanner.html:38
+#: templates/files/clamav/scanner.html:78
 msgid "Scan is complete!"
-msgstr "Escaneo finalizado!"
+msgstr ""
 
-#: templates/malware_scanner.html:44
+#: templates/files/clamav/scanner.html:84
 msgid "Scan Results"
-msgstr "Resultados del escaneo"
+msgstr ""
 
-#: templates/memcached.html:19
-msgid "Enabling Memcached service.."
-msgstr "Habilitando el servicio Memcached.."
+#: templates/files/filemanager/actions_buttons.html:10
+#: templates/files/filemanager/copy.html:128
+msgid "Copy"
+msgstr ""
 
-#: templates/memcached.html:22
-msgid "Installing Memcached service.. Please wait"
-msgstr "Instalando el servicio Memcached.. Espere por favor"
+#: templates/files/filemanager/actions_buttons.html:14
+#: templates/files/filemanager/move.html:130
+msgid "Move"
+msgstr ""
 
-#: templates/memcached.html:26
-msgid "Disabling Memcached service.."
-msgstr "Desactivando el servicio Memcached.."
+#: templates/files/filemanager/actions_buttons.html:26
+msgid "View"
+msgstr ""
 
-#: templates/memcached.html:83
-msgid "Error fetching log content."
-msgstr "Error al recuperar el contenido del registro."
+#: templates/files/filemanager/actions_buttons.html:34
+#: templates/files/filemanager/modals/rename.html:40
+#: templates/files/filemanager/rename.html:37
+msgid "Rename"
+msgstr ""
 
-#: templates/memcached.html:113
-msgid "Memcached is not currently installed."
-msgstr "Memcached no está instalado actualmente."
+#: templates/files/filemanager/actions_buttons.html:42
+#: templates/files/filemanager/compress.html:48
+msgid "Compress"
+msgstr ""
 
-#: templates/memcached.html:114
-msgid "To install Memcached click on the button bellow."
-msgstr "Para instalar Memcached haga clic en el botón de abajo."
+#: templates/files/filemanager/actions_buttons.html:46
+#: templates/files/filemanager/extract.html:50
+msgid "Extract"
+msgstr ""
 
-#: templates/memcached.html:117
-msgid "INSTALL MEMCACHED"
-msgstr "INSTALAR MEMCACHED"
+#: templates/files/filemanager/compress.html:21
+msgid "Archive path"
+msgstr ""
 
-#: templates/memcached.html:157
-msgid "Memcached server:"
-msgstr "Servidor Memcached:"
+#: templates/files/filemanager/compress.html:42
+msgid "compressing..."
+msgstr ""
 
-#: templates/memcached.html:166 templates/pm2.html:130 templates/redis.html:166
-msgid "Port:"
-msgstr "Puerto:"
+#: templates/files/filemanager/copy.html:5
+msgid "Copy items"
+msgstr ""
 
-#: templates/memcached.html:172
-msgid "View Memcached service Log"
-msgstr "Ver el registro del servicio Memcached"
+#: templates/files/filemanager/copy.html:22
+msgid "Copy to:"
+msgstr ""
 
-#: templates/memcached.html:179
-msgid "Memcached Memory Allocation"
-msgstr "Asignación de memoria Memcached"
+#: templates/files/filemanager/copy.html:122
+msgid "Copying..."
+msgstr ""
 
-#: templates/memcached.html:187
-msgid "You can allocate RAM to Memcached service."
-msgstr "Puede asignar RAM al servicio Memcached."
+#: templates/files/filemanager/delete.html:31
+msgid "deleting..."
+msgstr ""
 
-#: templates/memcached.html:192
-msgid "Current Memory limit for Memcached service"
-msgstr "Límite de memoria actual para el servicio Memcached"
+#: templates/files/filemanager/empty_directory.html:4
+msgid "No items found."
+msgstr ""
 
-#: templates/memcached.html:200 templates/redis.html:200
-msgid "Change Memory Allocation"
-msgstr "Cambiar la asignación de memoria"
+#: templates/files/filemanager/empty_directory.html:5
+msgid "Start creating new folders or uploading a new file!"
+msgstr ""
 
-#: templates/memcached.html:224
-msgid "Memcached service logs"
-msgstr "Registros del servicio Memcached"
+#: templates/files/filemanager/empty_directory_trash.html:4
+msgid "No items."
+msgstr ""
 
-#: templates/memcached.html:243
-msgid "Memcached is currently disabled."
-msgstr "Memcached is currently disabled."
+#: templates/files/filemanager/empty_directory_trash.html:5
+msgid "Trash is empty"
+msgstr ""
 
-#: templates/memcached.html:244
-msgid "To enable Memcached SERVER click on the button bellow."
-msgstr "Para activar Memcached SERVER haga clic en el botón de abajo."
+#: templates/files/filemanager/empty_trash.html:5
+msgid "No files in the Trash."
+msgstr ""
 
-#: templates/memcached.html:247
-msgid "START Memcached"
-msgstr "INICIAR Memcached"
+#: templates/files/filemanager/extract.html:25
+msgid "Archive name:"
+msgstr ""
 
-#: templates/memcached.html:252
-msgid "Memcached service status is unknown."
-msgstr "Se desconoce el estado del servicio Memcached."
+#: templates/files/filemanager/extract.html:30
+msgid "Extract destinaton:"
+msgstr ""
 
-#: templates/memcached.html:253
+#: templates/files/filemanager/extract.html:44
+msgid "Extracting..."
+msgstr ""
+
+#: templates/files/filemanager/inline_js_todo.html:136
+#: templates/files/filemanager/inline_js_trash.html:318
+msgid "Deselect"
+msgstr ""
+
+#: templates/files/filemanager/inline_js_todo.html:759
+msgid "Change permissions for"
+msgstr ""
+
+#: templates/files/filemanager/move.html:22
+msgid "Where to:"
+msgstr ""
+
+#: templates/files/filemanager/move.html:124
+msgid "moving..."
+msgstr ""
+
+#: templates/files/filemanager/new_file.html:8
+msgid "Create New File"
+msgstr ""
+
+#: templates/files/filemanager/new_file.html:20
+msgid "File Name"
+msgstr ""
+
+#: templates/files/filemanager/new_file.html:26
+msgid "Open in File Editor after creation"
+msgstr ""
+
+#: templates/files/filemanager/new_file.html:32
+msgid "New file will be created in:"
+msgstr ""
+
+#: templates/files/filemanager/new_file.html:38
+#: templates/files/filemanager/new_folder.html:32
+msgid "Create"
+msgstr ""
+
+#: templates/files/filemanager/new_folder.html:9
+msgid "Create New Folder"
+msgstr ""
+
+#: templates/files/filemanager/new_folder.html:20
+msgid "Folder Name"
+msgstr ""
+
+#: templates/files/filemanager/new_folder.html:26
+msgid "New folder will be created in:"
+msgstr ""
+
+#: templates/files/filemanager/permissions.html:10
+msgid "Set permissions"
+msgstr ""
+
+#: templates/files/filemanager/table.html:9
+#: templates/files/filemanager/table_trash.html:9
+msgid "Last Modified"
+msgstr ""
+
+#: templates/files/filemanager/table.html:24
+#: templates/files/filemanager/table_trash.html:34
+msgid "Link target"
+msgstr ""
+
+#: templates/files/filemanager/table.html:97
+#: templates/files/filemanager/table_trash.html:88
+msgid "Calculate"
+msgstr ""
+
+#: templates/files/filemanager/table_trash.html:15
+msgid "Deleted"
+msgstr ""
+
+#: templates/manager/autoinstaller.html:10
+msgid "Quickly install a variety of applications such as"
+msgstr ""
+
+#: templates/manager/autoinstaller.html:11
+msgid "and others."
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:116
+msgid "Saved successfully!"
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:117
+msgid "View your site"
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:117
+msgid "or close the modal and keep editing."
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:119
+msgid "Success"
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:123
+msgid "Error"
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:124
+msgid "Failed to save."
+msgstr ""
+
+#: templates/manager/grapejs_editor.html:124
+msgid "Copy code from HTML and CSS tabs, then reload the page to try again."
+msgstr ""
+
+#: templates/manager/mautic.html:57 templates/manager/mautic_install.html:318
+msgid "Mautic version:"
+msgstr ""
+
+#: templates/manager/mautic.html:69 templates/manager/wordpress.html:76
+msgid "PHP version:"
+msgstr ""
+
+#: templates/manager/mautic.html:88 templates/manager/wordpress.html:95
+msgid "MySQL version:"
+msgstr ""
+
+#: templates/manager/mautic.html:110 templates/manager/wordpress.html:117
+msgid "Created:"
+msgstr ""
+
+#: templates/manager/mautic.html:128 templates/manager/wordpress.html:135
+msgid "Select option"
+msgstr ""
+
+#: templates/manager/mautic.html:130 templates/manager/mautic.html:146
+#: templates/manager/python_node_apps.html:125
+#: templates/manager/python_node_apps.html:142 templates/manager/ruby.html:137
+#: templates/manager/ruby.html:153 templates/manager/wordpress.html:137
+#: templates/manager/wordpress.html:158
+msgid "Overview"
+msgstr ""
+
+#: templates/manager/mautic.html:199
+#: templates/manager/python_node_apps.html:1044 templates/manager/ruby.html:604
+#: templates/manager/websitebuilder.html:375
+#: templates/manager/wordpress.html:254
+msgid "Open folder in File Manager"
+msgstr ""
+
+#: templates/manager/mautic.html:209
+#: templates/manager/python_node_apps.html:1056 templates/manager/ruby.html:616
+#: templates/manager/websitebuilder.html:402
+#: templates/manager/wordpress.html:327
+msgid "Folder:"
+msgstr ""
+
+#: templates/manager/mautic.html:213
+#: templates/manager/python_node_apps.html:1069 templates/manager/ruby.html:626
+#: templates/manager/websitebuilder.html:412
+#: templates/manager/wordpress.html:331
+msgid "Folder Size:"
+msgstr ""
+
+#: templates/manager/mautic.html:229 templates/manager/wordpress.html:347
+#: templates/mysql/users.html:72 templates/mysql/users.html:74
+#: templates/psql/users.html:72 templates/psql/users.html:74
+msgid "Database"
+msgstr ""
+
+#: templates/manager/mautic.html:245 templates/manager/wordpress.html:363
+msgid "Manage MySQL databases"
+msgstr ""
+
+#: templates/manager/mautic.html:256 templates/manager/wordpress.html:374
+msgid "Database Size:"
+msgstr ""
+
+#: templates/manager/mautic.html:260 templates/manager/wordpress.html:378
+msgid "Database Host:"
+msgstr ""
+
+#: templates/manager/mautic.html:261 templates/manager/wordpress.html:379
+msgid "localhost"
+msgstr ""
+
+#: templates/manager/mautic.html:263 templates/manager/wordpress.html:381
 msgid ""
-"Unable to determinate current Memcached servise status, try Start&Stop "
-"actions."
+"Remote MySQL host detected in wp-config.php file. Database size unavailable."
 msgstr ""
-"No se puede determinar el estado actual del servicio Memcached, pruebe las "
-"acciones Iniciar y Detener."
 
-#: templates/memcached.html:307 templates/memcached.html:323
-msgid "Disable Memcached service"
-msgstr "Desactivar el servicio Memcached"
+#: templates/manager/mautic.html:269 templates/manager/mautic_install.html:377
+#: templates/manager/wordpress.html:387
+#: templates/manager/wordpress_install.html:490
+msgid "Database Name:"
+msgstr ""
 
-#: templates/memcached.html:312 templates/memcached.html:327
-msgid "Enable Memcached service"
-msgstr "Activar el servicio Memcached"
+#: templates/manager/mautic.html:281 templates/manager/wordpress.html:399
+msgid "Table prefix:"
+msgstr ""
 
-#: templates/memcached.html:317
-msgid "Install Memcached"
-msgstr "Instalar Memcached"
+#: templates/manager/mautic.html:285 templates/manager/wordpress.html:403
+msgid "Database User:"
+msgstr ""
 
-#: templates/php.html:18
-msgid "SAVED"
-msgstr "GUARDADO"
+#: templates/manager/mautic.html:297 templates/manager/mautic_install.html:398
+#: templates/manager/wordpress.html:415
+#: templates/manager/wordpress_install.html:558 templates/psql/pgadmin.html:127
+#: templates/system/ssh.html:98
+msgid "Password:"
+msgstr ""
 
-#: templates/php.html:20
-msgid "ERROR"
-msgstr "ERROR"
+#: templates/manager/mautic.html:304 templates/manager/wordpress.html:422
+msgid "phpMyAdmin:"
+msgstr ""
 
-#: templates/php.html:41 templates/php.html:44 templates/php.html:50
-msgid "PHP"
-msgstr "PHP"
+#: templates/manager/mautic.html:319 templates/manager/wordpress.html:437
+msgid "Open database in phpMyAdmin"
+msgstr ""
 
-#: templates/php.html:41
-msgid "versions"
-msgstr "versiones"
+#: templates/manager/mautic.html:365 templates/manager/websitebuilder.html:121
+#: templates/manager/wordpress.html:1856
+msgid "Create a Backup"
+msgstr ""
 
-#: templates/php.html:44
-msgid "extensions"
-msgstr "extensiones"
+#: templates/manager/mautic.html:366 templates/manager/wordpress.html:1857
+msgid "Create a new backup of WordPress files and/or database."
+msgstr ""
 
-#: templates/php.html:47
-msgid "default"
-msgstr "predeterminado"
+#: templates/manager/mautic.html:371 templates/manager/wordpress.html:1862
+msgid "Backup Database"
+msgstr ""
 
-#: templates/php.html:47
-msgid "Default settings"
-msgstr "Ajustes predeterminados"
+#: templates/manager/mautic.html:376 templates/manager/websitebuilder.html:127
+#: templates/manager/wordpress.html:1867
+msgid "Backup Files"
+msgstr ""
 
-#: templates/php.html:50
-msgid "options"
-msgstr "opciones"
+#: templates/manager/mautic.html:384 templates/manager/websitebuilder.html:135
+#: templates/manager/wordpress.html:1875
+msgid "Generate Backup"
+msgstr ""
 
-#: templates/php.html:59
+#: templates/manager/mautic.html:394 templates/manager/websitebuilder.html:145
+#: templates/manager/wordpress.html:1885
+msgid "Restore from Backups"
+msgstr ""
+
+#: templates/manager/mautic.html:395 templates/manager/websitebuilder.html:146
+#: templates/manager/wordpress.html:1886
+msgid "Restore website files and/or database from a previous backup."
+msgstr ""
+
+#: templates/manager/mautic.html:405 templates/manager/websitebuilder.html:156
+#: templates/manager/wordpress.html:1896
+msgid "Display Backups"
+msgstr ""
+
+#: templates/manager/mautic.html:409 templates/manager/websitebuilder.html:160
+#: templates/manager/wordpress.html:1900
+msgid "Select a backup date:"
+msgstr ""
+
+#: templates/manager/mautic.html:421 templates/manager/websitebuilder.html:172
+#: templates/manager/websitebuilder.html:573
+#: templates/manager/wordpress.html:1912 templates/manager/wordpress.html:2554
+msgid "Start Restore"
+msgstr ""
+
+#: templates/manager/mautic.html:431 templates/manager/wordpress.html:1922
+msgid "Remove the"
+msgstr ""
+
+#: templates/manager/mautic.html:431 templates/manager/wordpress.html:1922
+msgid "website from this manager without actually deleting any files."
+msgstr ""
+
+#: templates/manager/mautic.html:432
+#: templates/manager/python_node_apps.html:753 templates/manager/ruby.html:331
+#: templates/manager/wordpress.html:1923
+msgid "All website data such as files and database remains."
+msgstr ""
+
+#: templates/manager/mautic.html:442 templates/manager/wordpress.html:1933
+msgid "Detach WordPress"
+msgstr ""
+
+#: templates/manager/mautic.html:454 templates/manager/websitebuilder.html:205
+#: templates/manager/wordpress.html:1945
+msgid "Confirm Detach"
+msgstr ""
+
+#: templates/manager/mautic.html:481 templates/manager/wordpress.html:1972
+msgid "Uninstall WordPress and delete all website files and the database."
+msgstr ""
+
+#: templates/manager/mautic.html:483 templates/manager/wordpress.html:1974
 msgid ""
-"Changing the PHP version will stop all the processes on your site. It takes "
-"1-2 seconds to complete. Be sure to check your script and plugin "
-"requirements to know which PHP version works best for your website."
+"All WordPress data will be permanently deleted. There is no coming back "
+"after you press delete."
 msgstr ""
-"Cambiar la versión de PHP detendrá todos los procesos de su sitio. Tarda 1-2 "
-"segundos en completarse. Asegúrese de comprobar los requisitos de su script "
-"y plugin para saber qué versión de PHP funciona mejor para su sitio web."
 
-#: templates/php.html:65
-msgid "Current"
-msgstr "Actual"
-
-#: templates/dashboard/dashboard.html:344 templates/php.html:65
-#: templates/php.html:108
-msgid "PHP Version"
-msgstr "Versión de PHP"
-
-#: templates/php.html:66 templates/php.html:108 templates/php.html:152
-msgid "Change"
-msgstr "Cambiar"
-
-#: templates/php.html:66
-msgid ">PHP version for domain"
-msgstr ">Versión de PHP para el dominio"
-
-#: templates/php.html:130
-msgid "Default PHP version:"
-msgstr "Versión PHP predeterminada:"
-
-#: templates/php.html:134
-msgid ""
-"The PHP version that is used by default for newly added domains is the one "
-"that you choose here."
+#: templates/manager/mautic.html:492 templates/manager/wordpress.html:1983
+msgid "Uninstall WordPress"
 msgstr ""
-"La versión de PHP que se utiliza por defecto para los dominios recién "
-"agregados es la que usted elija aquí."
 
-#: templates/php.html:136
-msgid "Current default PHP version:"
-msgstr "Versión actual de PHP por defecto:"
-
-#: templates/php.html:140
-msgid "Change PHP Version to be used for new domains:"
-msgstr "Cambiar la versión de PHP que se utilizará para los nuevos dominios:"
-
-#: templates/php.html:145 templates/php.html:194 templates/php.html:316
-msgid "Select PHP Version"
-msgstr "Seleccionar versión de PHP"
-
-#: templates/php.html:173
-msgid "Install a new version"
-msgstr "Instalar una nueva versión"
-
-#: templates/php.html:177
-msgid ""
-"For best performance we recommend to only install PHP versions that you will "
-"be activelly using."
+#: templates/manager/mautic.html:504 templates/manager/wordpress.html:1995
+msgid "Confirm Uninstall"
 msgstr ""
-"Para un mejor rendimiento, recomendamos instalar sólo las versiones de PHP "
-"que vaya a utilizar activamente."
 
-#: templates/php.html:179
-msgid "Currently installed PHP versions"
-msgstr "Versiones de PHP instaladas actualmente"
-
-#: templates/php.html:186
-msgid "Select PHP Version to Install:"
-msgstr "Seleccione la versión de PHP a instalar:"
-
-#: templates/php.html:202 templates/wordpress.html:828
-msgid "Install"
-msgstr "Instalar"
-
-#: templates/php.html:217
-msgid "PHP version installation log"
-msgstr "Registro de instalación de la versión de PHP"
-
-#: templates/php.html:330
-msgid "No PHP versions found."
-msgstr "No se han encontrado versiones de PHP."
-
-#: templates/php.html:335
-msgid "Error fetching PHP versions."
-msgstr "Error en la búsqueda de versiones de PHP."
-
-#: templates/php.html:445
-msgid "Edit PHP.INI"
-msgstr "Editar PHP.INI"
-
-#: templates/php.html:449
-msgid "Setting"
-msgstr "Ajuste"
-
-#: templates/php_ini_editor.html:101
-msgid ""
-"PHP.INI Editor allows you to modify PHP settings stored in the php.ini "
-"configuration file, such as memory limits, error reporting, and extension "
-"settings."
+#: templates/manager/mautic.html:521 templates/manager/wordpress.html:2012
+msgid "WordPress uninstall process started. Please wait."
 msgstr ""
-"PHP.INI Editor le permite modificar los ajustes de PHP almacenados en el "
-"archivo de configuración php.ini, como los límites de memoria, los informes "
-"de errores y los ajustes de extensión."
 
-#: templates/php_ini_editor.html:105
-msgid "Select PHP Version:"
-msgstr "Seleccionar versión de PHP:"
-
-#: templates/php_ini_editor.html:107
-msgid "Select a PHP Version to edit .ini file"
-msgstr "Seleccionar una versión de PHP para editar el archivo .ini"
-
-#: templates/pm2.html:38
-msgid "available"
-msgstr "disponible"
-
-#: templates/pm2.html:40
-msgid "already in use"
-msgstr "ya en uso"
-
-#: templates/pm2.html:62
-msgid "file exists"
-msgstr "el archivo existe"
-
-#: templates/pm2.html:64
-msgid "file does not exist!"
-msgstr "el archivo no existe!"
-
-#: templates/pm2.html:88
-msgid "Create a new Application"
-msgstr "Crear una nueva aplicación"
-
-#: templates/pm2.html:89
-msgid "Run a NodeJS or Python application."
-msgstr "Ejecutar una aplicación NodeJS o Python."
-
-#: templates/pm2.html:93
-msgid "Application URL:"
-msgstr "URL de la aplicación:"
-
-#: templates/pm2.html:101
-msgid "subfolder (optional)"
-msgstr "subcarpeta (opcional)"
-
-#: templates/pm2.html:106
-msgid "Application Startup file:"
-msgstr "Archivo de inicio de la aplicación:"
-
-#: templates/pm2.html:118
-msgid "Type:"
-msgstr "Tipo:"
-
-#: templates/pm2.html:120 templates/system/services_status.html:98
-msgid "NodeJS"
-msgstr "NodeJS"
-
-#: templates/pm2.html:121 templates/system/services_status.html:110
-msgid "Python"
-msgstr "Python"
-
-#: templates/pm2.html:140
-msgid "Watch:"
-msgstr "Observar:"
-
-#: templates/pm2.html:143
-msgid "Automatically restart app on file changes"
-msgstr "Reinicio automático de la aplicación al cambiar de archivo"
-
-#: templates/pm2.html:147
-msgid "Enable logs:"
-msgstr "Habilitar registros:"
-
-#: templates/pm2.html:150
-msgid "Collect logs"
-msgstr "Recoger registros"
-
-#: templates/pm2.html:195
-msgid "Application / Domain Name."
-msgstr "Aplicación / Dominio."
-
-#: templates/pm2.html:195 templates/pm2.html:315
-msgid "Application"
-msgstr "Aplicación"
-
-#: templates/pm2.html:197 templates/system/server_info.html:31
-msgid "Uptime"
-msgstr "Tiempo de actividad"
-
-#: templates/pm2.html:198
-msgid "Restarts"
-msgstr "Reinicia"
-
-#: templates/pm2.html:199
-msgid "Current status of the application process."
-msgstr "Estado actual del proceso de solicitud."
-
-#: templates/pm2.html:200 templates/user/stats.html:7
-msgid "CPU"
-msgstr "CPU"
-
-#: templates/pm2.html:201
-msgid "Memory"
-msgstr "Memoria"
-
-#: templates/pm2.html:202
-msgid ""
-"If watching is enabled, the application will automatically restart when its "
-"files are edited."
+#: templates/manager/mautic.html:528 templates/manager/wordpress.html:2019
+msgid "WordPress uninstalled successfully."
 msgstr ""
-"Si la observación está activada, la aplicación se reiniciará automáticamente "
-"cuando se editen sus archivos."
 
-#: templates/pm2.html:202
-msgid "Watching"
-msgstr "Observando"
-
-#: templates/domains/edit_dns_zone.html:116
-#: templates/domains/edit_dns_zone.html:259 templates/pm2.html:205
-#: templates/sites.html:151 templates/websites.html:1240
-msgid "Type"
-msgstr "Tipo"
-
-#: templates/pm2.html:206
-msgid "Port that the application is using."
-msgstr "Puerto que está utilizando la aplicación."
-
-#: templates/pm2.html:207
-msgid "Path to the application startup file (app.js)"
-msgstr "Ruta al archivo de inicio de la aplicación (app.js)"
-
-#: templates/pm2.html:207
-msgid "Startup file"
-msgstr "Archivo de inicio"
-
-#: templates/pm2.html:232
-msgid "Start"
-msgstr "Iniciar"
-
-#: templates/pm2.html:236
-msgid "Stop"
-msgstr "Parar"
-
-#: templates/pm2.html:241 templates/system/services_status.html:19
-#: templates/system/services_status.html:20
-#: templates/system/services_status.html:56
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: templates/pm2.html:272
-msgid "No PM2 data available."
-msgstr "No hay datos de PM2 disponibles."
-
-#: templates/pm2.html:283
-msgid "No existing Applications"
-msgstr "No existen aplicaciones"
-
-#: templates/pm2.html:284
-msgid ""
-"There are no existing applications. You can start a new NodeJS or Python app "
-"below."
+#: templates/manager/mautic.html:600 templates/manager/ruby.html:404
+#: templates/manager/wordpress.html:2091
+msgid "Administration"
 msgstr ""
-"No hay aplicaciones existentes. Puede iniciar una nueva aplicación NodeJS o "
-"Python a continuación."
 
-#: templates/pm2.html:286
-msgid " Create Application"
-msgstr " Crear aplicación"
-
-#: templates/process_manager.html:14
-msgid "TIME"
-msgstr "TIEMPO"
-
-#: templates/process_manager.html:17
-msgid "ACTION"
-msgstr "ACCIÓN"
-
-#: templates/process_manager.html:33
-msgid "View full command"
-msgstr "Ver comando completo"
-
-#: templates/process_manager.html:97
-msgid "Killing PID:"
-msgstr "Matando el PID:"
-
-#: templates/process_manager.html:97
-msgid "failed"
-msgstr "fallido"
-
-#: templates/process_manager.html:104
-msgid "terminated"
-msgstr "terminado"
-
-#: templates/processlist.html:6
-msgid ""
-"This interface lists all of the processes that currently run on any database "
-"on your server."
+#: templates/manager/mautic.html:651 templates/manager/wordpress.html:2250
+msgid "An error occurred fetching DB size."
 msgstr ""
-"Esta interfaz enumera todos los procesos que se ejecutan actualmente en "
-"cualquier base de datos de su servidor."
 
-#: templates/processlist.html:13
-msgid ""
-"Process ID: a unique identification number assigned by Linux systems to each "
-"process and application."
+#: templates/manager/mautic_install.html:10
+msgid "Install Mautic in a few clicks."
 msgstr ""
-"ID de proceso: número de identificación único asignado por los sistemas "
-"Linux a cada proceso y aplicación."
 
-#: templates/processlist.html:14
-msgid "Indicates the MySQL user who executed the process on the database."
-msgstr "Indica el usuario de MySQL que ejecutó el proceso en la base de datos."
-
-#: templates/processlist.html:15
-msgid ""
-"Displays the client&apos;s hostname and the port from which the process was "
-"executed (e.g., Host:0000)."
-msgstr ""
-"Muestra el nombre de host del cliente y el puerto desde el que se ejecutó el "
-"proceso (por ejemplo, Host:0000)."
-
-#: templates/processlist.html:16
-msgid ""
-"The database on which the process is running. This column will display NULL "
-"if the process is not associated with any database."
-msgstr ""
-"La base de datos en la que se está ejecutando el proceso. Esta columna "
-"mostrará NULL si el proceso no está asociado a ninguna base de datos."
-
-#: templates/processlist.html:17
-msgid "Type of command issued by the system to the database."
-msgstr "Tipo de comando emitido por el sistema a la base de datos."
-
-#: templates/processlist.html:18
-msgid ""
-"The duration, in seconds, that the process has remained in its current state."
-msgstr ""
-"La duración, en segundos, que el proceso ha permanecido en su estado actual."
-
-#: templates/processlist.html:18
-msgid "Time"
-msgstr "Tiempo"
-
-#: templates/processlist.html:19
-msgid ""
-"The action, state, or event of the process. This column will display NULL "
-"for processes in the SHOW PROCESSLIST state."
-msgstr ""
-"Acción, estado o evento del proceso. Esta columna mostrará NULL para los "
-"procesos en estado SHOW PROCESSLIST."
-
-#: templates/processlist.html:19
-msgid "State"
-msgstr "Estado"
-
-#: templates/processlist.html:20
-msgid ""
-"Text of the statement that the process is currently executing. If the "
-"process is not executing a statement, this column displays NULL. It may also "
-"show a statement sent to the server or an inner statement used to execute "
-"other statements."
-msgstr ""
-"Texto de la sentencia que el proceso está ejecutando actualmente. Si el "
-"proceso no está ejecutando ninguna sentencia, esta columna muestra NULL. "
-"También puede mostrar una sentencia enviada al servidor o una sentencia "
-"interna utilizada para ejecutar otras sentencias."
-
-#: templates/processlist.html:20
-msgid "Info"
-msgstr "Info"
-
-#: templates/redis.html:19
-msgid "Enabling REDIS service.."
-msgstr "Activando el servicio REDIS..."
-
-#: templates/redis.html:22
-msgid "Installing REDIS service.. Please wait"
-msgstr "Instalando el servicio REDIS... Por favor aguarde"
-
-#: templates/redis.html:25
-msgid "Disabling REDIS service.."
-msgstr "Desactivando el servicio REDIS..."
-
-#: templates/redis.html:113
-msgid "REDIS is not currently installed."
-msgstr "REDIS no está instalado actualmente..."
-
-#: templates/redis.html:114
-msgid "To install REDIS click on the button bellow."
-msgstr "Para instalar REDIS haga clic en el botón de abajo."
-
-#: templates/redis.html:117
-msgid "INSTALL REDIS"
-msgstr "INSTALAR REDIS"
-
-#: templates/redis.html:157
-msgid "REDIS server:"
-msgstr "Servidor REDIS:"
-
-#: templates/redis.html:172
-msgid "View Redis service Log"
-msgstr "Ver el registro del servicio Redis"
-
-#: templates/redis.html:179
-msgid "REDIS Memory Allocation"
-msgstr "Asignación de memoria para REDIS"
-
-#: templates/redis.html:187
-msgid "You can allocate RAM to REDIS service."
-msgstr "Puede asignar RAM al servicio REDIS."
-
-#: templates/redis.html:192
-msgid "Current Memory limit for REDIS service"
-msgstr "Límite de memoria actual para el servicio REDIS"
-
-#: templates/redis.html:224
-msgid "REDIS service logs"
-msgstr "Registros del servicio REDIS"
-
-#: templates/redis.html:243
-msgid "REDIS is currently disabled."
-msgstr "REDIS está actualmente desactivado."
-
-#: templates/redis.html:244
-msgid "To enable REDIS SERVER click on the button bellow."
-msgstr "Para activar el servidor REDIS haga clic en el botón de abajo."
-
-#: templates/redis.html:247
-msgid "START REDIS"
-msgstr "INICIAR REDIS"
-
-#: templates/redis.html:253
-msgid "REDIS service status is unknown."
-msgstr "El estado del servicio REDIS es desconocido."
-
-#: templates/redis.html:254
-msgid ""
-"Unable to determinate current REDIS servise status, try Start&Stop actions."
-msgstr ""
-"No se puede determinar el estado actual del servicio REDIS, intente iniciar "
-"y detener las acciones."
-
-#: templates/redis.html:308 templates/redis.html:323
-msgid "Disable REDIS service"
-msgstr "Deshabilitar servicio REDIS"
-
-#: templates/redis.html:313 templates/redis.html:327
-msgid "Enable REDIS service"
-msgstr "Habilitar servicio REDIS"
-
-#: templates/redis.html:318
-msgid "Install REDIS"
-msgstr "Instalar REDIS"
-
-#: templates/remote_mysql.html:18
-msgid "Enabling remote MySQL access.."
-msgstr "Habilitar el acceso remoto a MySQL..."
-
-#: templates/remote_mysql.html:19
-msgid "Remote MySQL access is enabled."
-msgstr "El acceso remoto a MySQL está activado."
-
-#: templates/remote_mysql.html:22
-msgid "Disabling remote MySQL access.."
-msgstr "Deshabilitar el acceso remoto a MySQL.."
-
-#: templates/remote_mysql.html:23
-msgid "Remote MySQL access is disabled."
-msgstr "El acceso remoto a MySQL está desactivado."
-
-#: templates/remote_mysql.html:97
-msgid ""
-"Remote MySQL access gives you the ability to connect to a MySQL database on "
-"this server from a another (remote) device or location over the internet."
-msgstr ""
-"El acceso remoto a MySQL le permite conectarse a una base de datos MySQL en "
-"este servidor desde otro dispositivo o ubicación (remota) a través de "
-"Internet."
-
-#: templates/remote_mysql.html:106
-msgid "Enabled<"
-msgstr "Habilitado<"
-
-#: templates/remote_mysql.html:110
-msgid " Unknown. Contact Administrator."
-msgstr " Desconocido. Contactar con el administrador."
-
-#: templates/remote_mysql.html:119
-msgid "Server IP address:"
-msgstr "Dirección IP del servidor:"
-
-#: templates/remote_mysql.html:126
-msgid "MySQL Port:"
-msgstr "Puerto MySQL:"
-
-#: templates/remote_mysql.html:127
-msgid "*Port is random generated and unique to your account."
-msgstr "*El puerto se genera aleatoriamente y es exclusivo de su cuenta."
-
-#: templates/remote_mysql.html:143
-msgid "Important Security Notice"
-msgstr "Aviso de seguridad importante"
-
-#: templates/remote_mysql.html:151
-msgid ""
-"Allowing remote MySQL access opens your database to connections from the "
-"entire internet, which may pose a security risk. Please consider the "
-"following:"
-msgstr ""
-"Permitir el acceso remoto a MySQL abre su base de datos a conexiones de todo "
-"Internet, lo que puede suponer un riesgo para la seguridad. Tenga en cuenta "
-"lo siguiente:"
-
-#: templates/remote_mysql.html:153
-msgid "Security Vulnerabilities"
-msgstr "Vulnerabilidades de seguridad"
-
-#: templates/remote_mysql.html:153
-msgid ""
-"Allowing access from the web can expose your database to potential security "
-"vulnerabilities, increasing the risk of unauthorized access, data breaches, "
-"and data loss."
-msgstr ""
-"Permitir el acceso desde la Web puede exponer su base de datos a posibles "
-"vulnerabilidades de seguridad, aumentando el riesgo de acceso no autorizado, "
-"violación de datos y pérdida de datos."
-
-#: templates/remote_mysql.html:154
-msgid "Data Privacy"
-msgstr "Privacidad de datos"
-
-#: templates/remote_mysql.html:154
-msgid ""
-"Your sensitive data may be at risk if not properly secured. Make sure to use "
-"strong passwords and encryption to protect your information."
-msgstr ""
-"Sus datos confidenciales pueden estar en peligro si no se protegen "
-"adecuadamente. Asegúrate de utilizar contraseñas seguras y cifrado para "
-"proteger tu información."
-
-#: templates/remote_mysql.html:155
-msgid "Firewall and Access Control"
-msgstr "Cortafuegos y control de acceso"
-
-#: templates/remote_mysql.html:155
-msgid ""
-"It is crucial to set up robust firewall rules and access control to restrict "
-"connections only to trusted IP addresses."
-msgstr ""
-"Es crucial establecer reglas sólidas de cortafuegos y control de acceso para "
-"restringir las conexiones sólo a las direcciones IP de confianza."
-
-#: templates/remote_mysql.html:156
-msgid "Regular Backups"
-msgstr "Copias de seguridad periódicas"
-
-#: templates/remote_mysql.html:156
-msgid ""
-"Ensure that you have regular database backups in place to recover data in "
-"case of any security incidents."
-msgstr ""
-"Asegúrese de que dispone de copias de seguridad periódicas de la base de "
-"datos para recuperar los datos en caso de incidentes de seguridad."
-
-#: templates/remote_mysql.html:158
-msgid ""
-"Before enabling remote MySQL access, please review your security settings, "
-"and consider the potential risks carefully. If you're unsure about the "
-"security implications or need assistance, consult with your system "
-"administrator or a security expert."
-msgstr ""
-"Antes de habilitar el acceso remoto a MySQL, por favor revise su "
-"configuración de seguridad, y considere los riesgos potenciales "
-"cuidadosamente. Si no está seguro de las implicaciones de seguridad o "
-"necesita ayuda, consulte con el administrador de su sistema o con un experto "
-"en seguridad."
-
-#: templates/remote_mysql.html:160
-msgid ""
-"Your data security is important to us, and we recommend taking the necessary "
-"precautions to protect it."
-msgstr ""
-"La seguridad de sus datos es importante para nosotros, por lo que le "
-"recomendamos que tome las precauciones necesarias para protegerlos."
-
-#: templates/remote_mysql.html:181 templates/remote_mysql.html:191
-msgid "Disable Remote MySQL Access"
-msgstr "Desactivar el acceso remoto a MySQL"
-
-#: templates/remote_mysql.html:186 templates/remote_mysql.html:195
-msgid "Enable Remote MySQL Access"
-msgstr "Activar el acceso remoto a MySQL"
-
-#: templates/sites.html:17
-msgid "New Website"
-msgstr "Nuevo sitio web"
-
-#: templates/sites.html:146
-msgid "Site Name"
-msgstr "Nombre del sitio"
-
-#: templates/sites.html:148 templates/wordpress.html:455
-msgid "Admin Email"
-msgstr "Email del admin"
-
-#: templates/sites.html:149 templates/system/server_info.html:82
-msgid "Version"
-msgstr "Versión"
-
-#: templates/sites.html:150
-msgid "Created Date"
-msgstr "Fecha de creación"
-
-#: templates/ssh.html:19
-msgid "Enabling SSH access.."
-msgstr "Activando acceso SSH..."
-
-#: templates/ssh.html:22
-msgid "Disabling SSH access.."
-msgstr "Desactivando acceso SSH..."
-
-#: templates/ssh.html:102
-msgid "SSH access is currently disabled."
-msgstr "El acceso SSH está actualmente desactivado."
-
-#: templates/ssh.html:105
-msgid "SSH service status is unknown. Contact Administrator."
-msgstr ""
-"Se desconoce el estado del servicio SSH. Póngase en contacto con el "
-"administrador."
-
-#: templates/ssh.html:122
-msgid "SSH Connection Information"
-msgstr "Información de conexión SSH"
-
-#: templates/ssh.html:128
-msgid "IP address:"
-msgstr "Dirección IP:"
-
-#: templates/ssh.html:132
-msgid "SSH Port:"
-msgstr "Puerto SSH:"
-
-#: templates/ssh.html:133
-msgid "CONTAINER NOT RUNNING"
-msgstr "CONTENEDOR INACTIVO"
-
-#: templates/ssh.html:142
-msgid "Change SSH Password"
-msgstr "Cambiar contraseña SSH"
-
-#: templates/ssh.html:165
-msgid "Change password for SSH user"
-msgstr "Cambiar contraseña de usuario SSH"
-
-#: templates/ssh.html:173 templates/user/account.html:57
-msgid "New Password:"
-msgstr "Nueva contraseña:"
-
-#: templates/ssh.html:179
-msgid "Password can not be viewed after changing, please make sure to"
-msgstr ""
-"La contraseña no se puede ver después de cambiar, por favor asegúrese de"
-
-#: templates/ssh.html:179
-msgid "copy the new password"
-msgstr "haber copiado la nueva contraseña"
-
-#: templates/ssh.html:204 templates/ssh.html:214
-msgid "Disable SSH Access"
-msgstr "Desactivar el acceso SSH"
-
-#: templates/ssh.html:209 templates/ssh.html:218
-msgid "Enable SSH Access"
-msgstr "Activar el acceso SSH"
-
-#: templates/ssl.html:126
-msgid "Display"
-msgstr "Mostrar"
-
-#: templates/ssl.html:127
-msgid "DNS Zone"
-msgstr "Zona DNS"
-
-#: templates/domains/domains.html:206 templates/ssl.html:128
-msgid "Redirect"
-msgstr "Redirección"
-
-#: templates/ssl.html:135
-msgid "SSL Status"
-msgstr "Estado SSL"
-
-#: templates/ssl.html:146
-msgid "No SSL installed"
-msgstr "No hay SSL instalado"
-
-#: templates/ssl.html:148
-msgid "AutoSSL Domain Validated"
-msgstr "Dominio validado por AutoSSL"
-
-#: templates/ssl.html:149
-msgid "Expires on"
-msgstr "Expira el"
-
-#: templates/ssl.html:149
-msgid "View Certificate"
-msgstr "Ver certificado"
-
-#: templates/ssl.html:149
-msgid "Private key"
-msgstr "Clave privada"
-
-#: templates/ssl.html:152
-msgid "SSL check is in progress.. please click here to refresh."
-msgstr "La comprobación de SSL está en curso. Haga clic aquí para refrescar."
-
-#: templates/ssl.html:185
-msgid "Renew"
-msgstr "Renovar"
-
-#: templates/ssl.html:188
-msgid "Exclude"
-msgstr "Exluir"
-
-#: templates/ssl.html:202 templates/user/account.html:65
-#: templates/wordpress.html:284
-msgid "Generate"
-msgstr "Generar"
-
-#: templates/ssl.html:242
-msgid "Error fetching file content:"
-msgstr "Error al recuperar el contenido del archivo:"
-
-#: templates/ssl.html:255
-msgid "Running AutoSSL renewal..."
-msgstr "Ejecutando renovación AutoSSL..."
-
-#: templates/ssl.html:268
-msgid "AutoSSL Renewal Completed"
-msgstr "Renovación AutoSSL completada"
-
-#: templates/ssl.html:275
-msgid "AutoSSL Renewal Complete"
-msgstr "Renovación AutoSSL completa"
-
-#: templates/ssl.html:293
-msgid "Running AutoSSL renewal for "
-msgstr "Ejecutando renovación AutoSSL para "
-
-#: templates/ssl.html:309 templates/ssl.html:317
-msgid "Renewal for"
-msgstr "Renovación para"
-
-#: templates/ssl.html:309 templates/ssl.html:317
-msgid "Completed"
-msgstr "Completado"
-
-#: templates/ssl.html:338
-msgid "Run AutoSSL"
-msgstr "Ejecutar AutoSSL"
-
-#: templates/ssl.html:338 templates/system/modsecurity.html:192
-msgid "for All Domains"
-msgstr "para todos los dominios"
-
-#: templates/ssl.html:351
-msgid ""
-"When you create a domain, the system will attempt to secure that domain with "
-"a free Let's Encrypt certificate."
-msgstr ""
-"Al crear un dominio, el sistema intentará protegerlo con un certificado "
-"gratuito de Let's Encrypt."
-
-#: templates/websites.html:51
-msgid "General"
-msgstr "General"
-
-#: templates/websites.html:54
-msgid "Updates"
-msgstr "Actualizaciones"
-
-#: templates/websites.html:57
-msgid "Debugging"
-msgstr "Depuración"
-
-#: templates/websites.html:60
-msgid "Security"
-msgstr "Seguridad"
-
-#: templates/websites.html:169
-msgid "Site URL"
-msgstr "URL del sitio"
-
-#: templates/websites.html:180
+#: templates/manager/mautic_install.html:27
 msgid "Website Name"
-msgstr "Nombre del sitio web"
+msgstr ""
 
-#: templates/websites.html:184
+#: templates/manager/mautic_install.html:29
+msgid "My Site"
+msgstr ""
+
+#: templates/manager/mautic_install.html:41
+#: templates/manager/pm2_install.html:163
+#: templates/manager/websitebuilder_install.html:30
+#: templates/manager/wordpress_install.html:98
+msgid "Select a domain"
+msgstr ""
+
+#: templates/manager/mautic_install.html:328
+#: templates/manager/websitebuilder_install.html:46
+#: templates/manager/wordpress_install.html:424
+msgid "Website files will be stored in folder:"
+msgstr ""
+
+#: templates/manager/mautic_install.html:384
+#: templates/manager/wordpress_install.html:512
+msgid "Table Prefix:"
+msgstr ""
+
+#: templates/manager/mautic_install.html:391
+#: templates/manager/wordpress_install.html:534
+msgid "Database Username:"
+msgstr ""
+
+#: templates/manager/mautic_install.html:445
+#: templates/manager/pm2_install.html:631
+#: templates/manager/websitebuilder_install.html:100
+#: templates/manager/wordpress_install.html:613
+msgid "Back to AutoInstaller"
+msgstr ""
+
+#: templates/manager/mautic_install.html:475
+#: templates/manager/pm2_install.html:661
+#: templates/manager/websitebuilder_install.html:132
+#: templates/manager/wordpress_install.html:643
+msgid "Please select a domain name."
+msgstr ""
+
+#: templates/manager/mautic_install.html:481
+msgid "Mautic install started. Please wait for the process to finish."
+msgstr ""
+
+#: templates/manager/mautic_install.html:531
+#: templates/manager/pm2_install.html:718
+#: templates/manager/websitebuilder_install.html:196
+#: templates/manager/wordpress_install.html:699
+msgid "Error, please check the install log bellow the form."
+msgstr ""
+
+#: templates/manager/mautic_install.html:548
+#: templates/manager/pm2_install.html:735
+#: templates/manager/websitebuilder_install.html:213
+#: templates/manager/wordpress_install.html:716
+msgid "Fetch error. Please try again."
+msgstr ""
+
+#: templates/manager/mautic_install.html:594
+msgid "Error fetching Mautic versions from Github. Please refresh page."
+msgstr ""
+
+#: templates/manager/mautic_install.html:601
+#: templates/manager/wordpress_install.html:769
+msgid "Error fetching versions"
+msgstr ""
+
+#: templates/manager/new.html:10
+msgid "New Website"
+msgstr ""
+
+#: templates/manager/new.html:11
+msgid "AutoInstall"
+msgstr ""
+
+#: templates/manager/new.html:11
+msgid "applications."
+msgstr ""
+
+#: templates/manager/new.html:73
+msgid "What kind of website would you like to create?"
+msgstr ""
+
+#: templates/manager/new.html:75
+msgid "What kind of site would you like to create?"
+msgstr ""
+
+#: templates/manager/new.html:92
+msgid "1-Click Install Applications"
+msgstr ""
+
+#: templates/manager/new.html:100
+msgid "Upload Files"
+msgstr ""
+
+#: templates/manager/pm2_install.html:9
+msgid "Create a new application."
+msgstr ""
+
+#: templates/manager/pm2_install.html:39 templates/manager/pm2_install.html:47
+msgid "Incorrect file extension - Please use"
+msgstr ""
+
+#: templates/manager/pm2_install.html:39 templates/manager/pm2_install.html:47
+msgid "for"
+msgstr ""
+
+#: templates/manager/pm2_install.html:65
+msgid "file exists"
+msgstr ""
+
+#: templates/manager/pm2_install.html:67
+msgid "file does not exist!"
+msgstr ""
+
+#: templates/manager/pm2_install.html:104
+msgid "Container name is only visible on backend."
+msgstr ""
+
+#: templates/manager/pm2_install.html:129
+msgid "Port is optional, if left blank port '80' will be used."
+msgstr ""
+
+#: templates/manager/pm2_install.html:153
+msgid "Choose a domain name and optional subdirectory to create reverse-proxy."
+msgstr ""
+
+#: templates/manager/pm2_install.html:180
+#: templates/manager/python_node_apps.html:213 templates/manager/ruby.html:636
+msgid "Startup file:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:203
+msgid "Custom startup command"
+msgstr ""
+
+#: templates/manager/pm2_install.html:215
+msgid ""
+"Startup file is the main entry point of the application, usually app.py or "
+"app.js file."
+msgstr ""
+
+#: templates/manager/pm2_install.html:236
+msgid "Startup command"
+msgstr ""
+
+#: templates/manager/pm2_install.html:245
+msgid ""
+"If custom startup command is provided, it will be executed instead of the "
+"default"
+msgstr ""
+
+#: templates/manager/pm2_install.html:265
+msgid "Type:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:313
+msgid "Create a new NodeJS application"
+msgstr ""
+
+#: templates/manager/pm2_install.html:314
+msgid "Run NPM install before starting the application"
+msgstr ""
+
+#: templates/manager/pm2_install.html:315
+msgid ""
+"When enabled, this option will first run npm install using the package.json "
+"file, then launch the application. If the application is already built, you "
+"can skip this option."
+msgstr ""
+
+#: templates/manager/pm2_install.html:319
+msgid "Create a new Python application"
+msgstr ""
+
+#: templates/manager/pm2_install.html:320
+msgid "Run PIP install before starting the application"
+msgstr ""
+
+#: templates/manager/pm2_install.html:321
+msgid ""
+"When enabled, this option will first run pip install using the "
+"requirements.txt file, then launch the application. If the application is "
+"already built, you can skip this option."
+msgstr ""
+
+#: templates/manager/pm2_install.html:324
+msgid "Create a new application"
+msgstr ""
+
+#: templates/manager/pm2_install.html:326
+msgid "If the application is already built, you can skip this option."
+msgstr ""
+
+#: templates/manager/pm2_install.html:370
+#: templates/manager/python_node_apps.html:82
+#: templates/manager/python_node_apps.html:430
+#: templates/manager/python_node_apps.html:440
+#: templates/mysql/phpmyadmin.html:134 templates/psql/pgadmin.html:139
+msgid "Version:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:379
+msgid "Select version of Python/NodeJS to use for this application."
+msgstr ""
+
+#: templates/manager/pm2_install.html:458
+msgid "Run NPM install before starting the app"
+msgstr ""
+
+#: templates/manager/pm2_install.html:468
+msgid ""
+"When enabled, this option will first run npm install using the package.json "
+"file, then launch the application. "
+msgstr ""
+
+#: templates/manager/pm2_install.html:481
+msgid "Application files will be stored in folder:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:514
+msgid "Service name to use in reverse-proxy:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:566
+#: templates/manager/wordpress_install.html:477
+msgid "Advanced Options"
+msgstr ""
+
+#: templates/manager/pm2_install.html:578
+msgid "CPU cores:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:587
+msgid "Restrict CPU cores that the container can use."
+msgstr ""
+
+#: templates/manager/pm2_install.html:598
+msgid "Memory:"
+msgstr ""
+
+#: templates/manager/pm2_install.html:607
+msgid "Physical Memory (in GB) that the container can use."
+msgstr ""
+
+#: templates/manager/pm2_install.html:667
+msgid "Application setup started. Please wait for the process to finish."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:43 templates/manager/ruby.html:54
+msgid "Status:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:65
+msgid "Inactive"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:78
+msgid "NodeJS"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:80
+msgid "Python"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:94
+msgid "CPU limit:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:104
+#: templates/mysql/phpmyadmin.html:125
+msgid "Memory limit:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:126
+#: templates/manager/python_node_apps.html:149
+msgid "Install Packages"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:183
+msgid " and custom port "
+msgstr ""
+
+#: templates/manager/python_node_apps.html:183
+msgid "on which the application is accessible from other services."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:205
+msgid "Startup"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:206
+msgid ""
+"Configure startup file and if install should be run before starting the "
+"application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:222
+msgid ""
+"If no custom startup command is provided, this file is executed with command:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:275
+msgid "Custom startup command:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:284
+msgid ""
+"You can provide a custom startup command with flags to be used instead of "
+"the default:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:332
+msgid "Work dir:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:341
+msgid ""
+"Set the working directory inside which packages are installed with command:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:343
+#: templates/manager/python_node_apps.html:397
+msgid "install"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:386
+msgid "Install packages before startup:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:395
+msgid ""
+"If enabled, this command is executed before the custom startup command or "
+"startup file:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:431
+msgid ""
+"Change version, make sure to restart the application afterward by stopping "
+"and starting it."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:449
+msgid "Select"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:449
+msgid "version to use for the application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:522
+msgid "Resource limits"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:523
+msgid "Limit CPU and Memory available to the container."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:531
+msgid "CPU (cores):"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:540
+msgid "Set max number of CPU cores to allocate for this service."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:554
+msgid "Memory (GB):"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:563
+msgid "Set max size in GB for Memory to allocate for this service."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:579
+msgid "PIDs:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:588
+msgid "Set total of PIDs allowed for the application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:605
+msgid "PIDs can not currently be configured in Docker compose"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:620
+msgid "Save changes"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:636
+#: templates/manager/python_node_apps.html:690
+msgid "package.json"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:638
+#: templates/manager/python_node_apps.html:690
+msgid "requirements.txt"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:640
+msgid "file content:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:683
+msgid "NPM install"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:684
+#: templates/manager/python_node_apps.html:686
+msgid "PNPM install"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:690
+msgid "Edit file"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:709 templates/manager/ruby.html:287
+msgid "Loading application log.."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:731
+msgid "Error fetching container logs for application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:733
+msgid "Error fetching container logs for applicaiton:"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:751
+msgid ""
+"Stops the application, deletes docker container and removes it from Site "
+"Manager interface."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:762
+msgid "Delete Application"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:774
+msgid "Confirm delete"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:791 templates/manager/ruby.html:345
+msgid "Application removal started. Please wait."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:869
+msgid "Manage Containers"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:882 templates/manager/ruby.html:458
+msgid "Start"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:890 templates/manager/ruby.html:473
+msgid "Starting application. Please wait."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:902 templates/manager/ruby.html:478
+msgid "Application started successfully."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:908
+#: templates/manager/python_node_apps.html:915 templates/manager/ruby.html:481
+msgid "Error starting application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:927 templates/manager/ruby.html:495
+msgid "Stop"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:936 templates/manager/ruby.html:512
+msgid "Stopping application. Please wait."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:949 templates/manager/ruby.html:517
+msgid "Application stopped successfully."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:955
+#: templates/manager/python_node_apps.html:962 templates/manager/ruby.html:520
+msgid "Error stopping application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:977 templates/manager/ruby.html:537
+msgid "Restart"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:986 templates/manager/ruby.html:222
+#: templates/manager/ruby.html:554
+msgid "Application restart in progress. Please wait."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:996 templates/manager/ruby.html:557
+msgid "Application restarted successfully."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1002
+#: templates/manager/python_node_apps.html:1009 templates/manager/ruby.html:561
+msgid "Error restarting application."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1092 templates/manager/ruby.html:676
+#: templates/manager/sites.html:71 templates/manager/websitebuilder.html:451
+msgid "Created"
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1118 templates/manager/ruby.html:705
+#: templates/manager/websitebuilder.html:480
+#: templates/manager/wordpress.html:2461
+msgid "An error occurred fetching folder size from the container."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1170
+msgid "Cannot install while container is stopped."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1174
+msgid "Installing packages.. Please wait."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1195
+msgid "Package installation completed."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1197
+msgid "Package installation failed."
+msgstr ""
+
+#: templates/manager/python_node_apps.html:1202
+msgid "Error running package install for application."
+msgstr ""
+
+#: templates/manager/ruby.html:85
+msgid "Ruby:"
+msgstr ""
+
+#: templates/manager/ruby.html:105
+msgid "CPU usage:"
+msgstr ""
+
+#: templates/manager/ruby.html:114
+msgid "Memory usage:"
+msgstr ""
+
+#: templates/manager/ruby.html:185
+msgid "Uptime:"
+msgstr ""
+
+#: templates/manager/ruby.html:192
+msgid "Restarts:"
+msgstr ""
+
+#: templates/manager/ruby.html:201
+msgid "Watching:"
+msgstr ""
+
+#: templates/manager/ruby.html:205
+msgid "Enable"
+msgstr ""
+
+#: templates/manager/ruby.html:206
+msgid "Restart app with '--watch' flag"
+msgstr ""
+
+#: templates/manager/ruby.html:226
+msgid "Application restarted successfully and Watching is now enabled."
+msgstr ""
+
+#: templates/manager/ruby.html:229
+msgid "Error restarting application, Watching is not disabled."
+msgstr ""
+
+#: templates/manager/ruby.html:239
+msgid "Disable"
+msgstr ""
+
+#: templates/manager/ruby.html:240
+msgid "Stop app with '--watch' flag"
+msgstr ""
+
+#: templates/manager/ruby.html:255
+msgid "Stoppping applicaiton. Please wait."
+msgstr ""
+
+#: templates/manager/ruby.html:258
+msgid "Application successfully stopped and Watching is now disabled."
+msgstr ""
+
+#: templates/manager/ruby.html:262
+msgid "Error stopping application, Watching is not disabled."
+msgstr ""
+
+#: templates/manager/ruby.html:309
+msgid "Error fetching pm2 logs for application."
+msgstr ""
+
+#: templates/manager/ruby.html:311
+msgid "Error fetching pm2 logs for applicaiton:"
+msgstr ""
+
+#: templates/manager/ruby.html:329
+msgid "Stop the application and delete it from Site Manager."
+msgstr ""
+
+#: templates/manager/ruby.html:338
+msgid "Remove Application"
+msgstr ""
+
+#: templates/manager/ruby.html:445
+msgid "Open Applications Manager"
+msgstr ""
+
+#: templates/manager/sites.html:8
+msgid "and other websites."
+msgstr ""
+
+#: templates/manager/sites.html:49
+msgid "New"
+msgstr ""
+
+#: templates/manager/sites.html:65 templates/manager/wordpress.html:522
+#: templates/manager/wordpress.html:528
+msgid "Site Name"
+msgstr ""
+
+#: templates/manager/sites.html:79 templates/partials/pagespeed.html:4
+msgid "Speed"
+msgstr ""
+
+#: templates/manager/sites.html:372
+msgid "No websites yet"
+msgstr ""
+
+#: templates/manager/sites.html:373
+msgid "Create your first website to get started"
+msgstr ""
+
+#: templates/manager/sites.html:379
+msgid "New website"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:41 templates/php/ini_editor.html:112
+msgid "Open Editor"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:122
+msgid "Create a new backup of website files."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:182
+msgid ""
+"Remove the website from this manager without actually deleting any files."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:183
+msgid "All website data such as HTML and CSS files remains."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:193
+msgid "Detach website"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:232
+msgid "Delete Website Builder and delete all website files."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:234
+msgid ""
+"All website data will be permanently deleted. There is no coming back after "
+"you press delete."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:243
+msgid "Delete website"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:272
+msgid "Delete process started. Please wait."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:287
+msgid "Detach process started. Please wait."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:298
+msgid "An error occurred while detaching website. Please try again."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:510
+#: templates/manager/wordpress.html:2595
+msgid "Files Backup"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:530
+#: templates/manager/wordpress.html:2511
+msgid "Click again to confirm"
+msgstr ""
+
+#: templates/manager/websitebuilder.html:558
+#: templates/manager/wordpress.html:2539
+msgid "Restoring backup... Please wait."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:566
+#: templates/manager/wordpress.html:2547
+msgid "Restore request failed."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:618
+msgid ""
+"No options selected to backup. Please ensure that at least Files is selected."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:624
+#: templates/manager/wordpress.html:2617
+msgid "Generating website backup.. Please wait."
+msgstr ""
+
+#: templates/manager/websitebuilder.html:632
+#: templates/manager/wordpress.html:2625
+msgid "Backup request failed."
+msgstr ""
+
+#: templates/manager/websitebuilder_install.html:10
+msgid "Build a new HTML website using a drag-and-drop builder."
+msgstr ""
+
+#: templates/manager/websitebuilder_install.html:105
+msgid "Open Website Builder"
+msgstr ""
+
+#: templates/manager/websitebuilder_install.html:146
+msgid "Creating Website. Please wait for the process to finish."
+msgstr ""
+
+#: templates/manager/wordpress.html:58
+msgid "WP version:"
+msgstr ""
+
+#: templates/manager/wordpress.html:139 templates/manager/wordpress.html:175
+msgid "Maintenance"
+msgstr ""
+
+#: templates/manager/wordpress.html:140 templates/manager/wordpress.html:195
+msgid "Updates"
+msgstr ""
+
+#: templates/manager/wordpress.html:141 templates/manager/wordpress.html:202
+msgid "Debugging"
+msgstr ""
+
+#: templates/manager/wordpress.html:142 templates/manager/wordpress.html:186
+msgid "Security"
+msgstr ""
+
+#: templates/manager/wordpress.html:486
+msgid "URL"
+msgstr ""
+
+#: templates/manager/wordpress.html:487
+msgid "Site and Homepage URLs"
+msgstr ""
+
+#: templates/manager/wordpress.html:492
+msgid "Site URL"
+msgstr ""
+
+#: templates/manager/wordpress.html:505
+msgid "Homepage URL"
+msgstr ""
+
+#: templates/manager/wordpress.html:523
+msgid "Site Name and Description"
+msgstr ""
+
+#: templates/manager/wordpress.html:539
 msgid "Blog Description"
-msgstr "Descripción del blog"
+msgstr ""
 
-#: templates/websites.html:191
-msgid "No, registrations are disabled (default)"
-msgstr "No, las inscripciones están desactivadas (por defecto)"
+#: templates/manager/wordpress.html:555
+msgid "Email Settings"
+msgstr ""
 
-#: templates/websites.html:198
+#: templates/manager/wordpress.html:556
+msgid "Email address to receive admin emails"
+msgstr ""
+
+#: templates/manager/wordpress.html:561
 msgid "Administrator Email"
-msgstr "Email del administrador"
+msgstr ""
 
-#: templates/websites.html:204
-msgid "Allow pingbacks and trackbacks from other blogs (default)"
-msgstr "Permitir pingbacks y trackbacks de otros blogs (por defecto)"
+#: templates/manager/wordpress.html:572
+msgid ""
+"You will receive confirmation email on this address, and need to confirm."
+msgstr ""
 
-#: templates/websites.html:212
+#: templates/manager/wordpress.html:581
+msgid "New Registrations"
+msgstr ""
+
+#: templates/manager/wordpress.html:582
+msgid "Enable or disable registration of new users"
+msgstr ""
+
+#: templates/manager/wordpress.html:587
+msgid "User Registration"
+msgstr ""
+
+#: templates/manager/wordpress.html:589
+msgid "No, registrations are disabled (default)"
+msgstr ""
+
+#: templates/manager/wordpress.html:599
+msgid "SEO Visibility"
+msgstr ""
+
+#: templates/manager/wordpress.html:600
+msgid "Search Engine visibility"
+msgstr ""
+
+#: templates/manager/wordpress.html:605
+msgid "Website Visibility"
+msgstr ""
+
+#: templates/manager/wordpress.html:607
 msgid ""
 "I would like my blog to be visible to everyone, including search engines "
 "(default)"
 msgstr ""
-"Me gustaría que mi blog fuera visible para todo el mundo, incluidos los "
-"motores de búsqueda (por defecto)"
 
-#: templates/websites.html:221
+#: templates/manager/wordpress.html:616
+msgid "Pingbacks"
+msgstr ""
+
+#: templates/manager/wordpress.html:617
+msgid "Enable or disable pingbacks from other websites"
+msgstr ""
+
+#: templates/manager/wordpress.html:624
+msgid "Allow pingbacks and trackbacks from other blogs (default)"
+msgstr ""
+
+#: templates/manager/wordpress.html:635
 msgid "Update Settings"
-msgstr "Actualizar ajustes"
+msgstr ""
 
-#: templates/websites.html:228
-msgid "WordPress version:"
-msgstr "Versión de WordPress:"
+#: templates/manager/wordpress.html:758 templates/manager/wordpress.html:772
+msgid "Shuffle Salts"
+msgstr ""
 
-#: templates/websites.html:229
+#: templates/manager/wordpress.html:764
+msgid ""
+"WordPress salts are random strings stored in wp-config.php file that are "
+"used for the password hashing process. By periodically changing your keys "
+"and salts, you make it even harder for hackers to get their hands on your "
+"salts."
+msgstr ""
+
+#: templates/manager/wordpress.html:767
+msgid ""
+"Note: changing salts will automatically log out all logged-in users and "
+"force them to log in again."
+msgstr ""
+
+#: templates/manager/wordpress.html:830
+msgid "Check Integrity"
+msgstr ""
+
+#: templates/manager/wordpress.html:836
+msgid ""
+"If you suspect that this site is infected by malware, check the integrity of "
+"WordPress core files or Plugins by verifying them against their reference "
+"checksums from wordpress.org."
+msgstr ""
+
+#: templates/manager/wordpress.html:840
+msgid "Check WP Core"
+msgstr ""
+
+#: templates/manager/wordpress.html:842
+msgid "Check All Plugins"
+msgstr ""
+
+#: templates/manager/wordpress.html:862
+msgid "Checking integrity of WP Core files... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:917
+msgid "Checking integrity for all WordPress plugins... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:1000
+msgid "Reinstall"
+msgstr ""
+
+#: templates/manager/wordpress.html:1006
+msgid ""
+"If checksums fail to match, you can quickly reinstall WordPress core files "
+"or all plugins without affecting your site content."
+msgstr ""
+
+#: templates/manager/wordpress.html:1010
+msgid "Reinstall WP Core files"
+msgstr ""
+
+#: templates/manager/wordpress.html:1011
+msgid "Reinstall All Plugins"
+msgstr ""
+
+#: templates/manager/wordpress.html:1033
+msgid "Downloading WP core files... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:1079
+msgid "Downloading and re-installing all plugins... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:1136
+msgid "Current Maintenance Mode status"
+msgstr ""
+
+#: templates/manager/wordpress.html:1142
+msgid "Checking..."
+msgstr ""
+
+#: templates/manager/wordpress.html:1157 templates/user/activity.html:45
+#: templates/user/loginlog.html:51
+msgid "Action"
+msgstr ""
+
+#: templates/manager/wordpress.html:1158 templates/manager/wordpress.html:1164
+msgid "Enable/Disable Maintenance Mode"
+msgstr ""
+
+#: templates/manager/wordpress.html:1179
+msgid "Template"
+msgstr ""
+
+#: templates/manager/wordpress.html:1180
+msgid "Edit maintenance mode code"
+msgstr ""
+
+#: templates/manager/wordpress.html:1186
+msgid "Click to Edit"
+msgstr ""
+
+#: templates/manager/wordpress.html:1249
+msgid "Enabling maintenance mode... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:1251
+msgid "Disabling maintenance mode... Please wait."
+msgstr ""
+
+#: templates/manager/wordpress.html:1271
+msgid "Failed to change maintenance mode"
+msgstr ""
+
+#: templates/manager/wordpress.html:1297
+msgid "Current WP version."
+msgstr ""
+
+#: templates/manager/wordpress.html:1302
+msgid "Installed WordPress version:"
+msgstr ""
+
+#: templates/manager/wordpress.html:1309
+msgid "Latest WordPress version:"
+msgstr ""
+
+#: templates/manager/wordpress.html:1312
 msgid "Click to update WordPress core"
-msgstr "Haga clic para actualizar el núcleo de WordPress"
+msgstr ""
 
-#: templates/websites.html:268 templates/websites.html:269
-msgid "Minor update available:"
-msgstr "Actualización menor disponible:"
+#: templates/manager/wordpress.html:1386
+msgid "Core"
+msgstr ""
 
-#: templates/websites.html:274 templates/websites.html:275
-msgid "Major update available:"
-msgstr "Actualización importante disponible:"
+#: templates/manager/wordpress.html:1387
+msgid "Update preferences for WP core."
+msgstr ""
 
-#: templates/websites.html:284 templates/websites.html:285
-msgid "Up to date"
-msgstr "Actualizado"
+#: templates/manager/wordpress.html:1393
+msgid "Update WordPress automatically:"
+msgstr ""
 
-#: templates/websites.html:291 templates/websites.html:293
-msgid "Bad response from api.wordpress.org"
-msgstr "Respuesta incorrecta de api.wordpress.org"
-
-#: templates/websites.html:299 templates/websites.html:301
-msgid "Failed to reach api.wordpress.org"
-msgstr "Error al acceder a api.wordpress.org"
-
-#: templates/websites.html:397
-msgid "Update WordPress Core automattically:"
-msgstr "Actualizar automáticamente el núcleo de WordPress:"
-
-#: templates/websites.html:403 templates/websites.html:425
-#: templates/websites.html:438
+#: templates/manager/wordpress.html:1398 templates/manager/wordpress.html:1438
+#: templates/manager/wordpress.html:1466
 msgid "No, I will update manually when needed"
-msgstr "No, actualizaré manualmente cuando sea necesario"
+msgstr ""
 
-#: templates/websites.html:407
+#: templates/manager/wordpress.html:1401
 msgid "Yes, but only minor (security) updates"
-msgstr "Sí, pero sólo actualizaciones menores (de seguridad)"
+msgstr ""
 
-#: templates/websites.html:407
+#: templates/manager/wordpress.html:1401
 msgid "Recommended"
-msgstr "Recomendado"
+msgstr ""
 
-#: templates/websites.html:412
+#: templates/manager/wordpress.html:1405
 msgid "Yes, all (minor and major) updates"
-msgstr "Sí, todas las actualizaciones (menores y mayores)"
+msgstr ""
 
-#: templates/websites.html:421
+#: templates/manager/wordpress.html:1423
+msgid "Plugins"
+msgstr ""
+
+#: templates/manager/wordpress.html:1424
+msgid "Update preferences for WP plugins."
+msgstr ""
+
+#: templates/manager/wordpress.html:1430
+msgid "Update plugins automatically:"
+msgstr ""
+
+#: templates/manager/wordpress.html:1435
 msgid "Yes, all plugins will be automatically updated"
-msgstr "Sí, todos los plugins se actualizarán automáticamente"
+msgstr ""
 
-#: templates/websites.html:431
+#: templates/manager/wordpress.html:1453
+msgid "Themes"
+msgstr ""
+
+#: templates/manager/wordpress.html:1454
+msgid "Update preferences for WP themes."
+msgstr ""
+
+#: templates/manager/wordpress.html:1459
 msgid "Update themes automatically:"
-msgstr "Actualizar los temas automáticamente:"
+msgstr ""
 
-#: templates/websites.html:434
+#: templates/manager/wordpress.html:1462
 msgid "Yes, all themes will be automatically updated"
-msgstr "Sí, todos los temas se actualizarán automáticamente"
+msgstr ""
 
-#: templates/websites.html:442
+#: templates/manager/wordpress.html:1483
 msgid "Save Update Preferences"
-msgstr "Guardar preferencias de actualización"
+msgstr ""
 
-#: templates/websites.html:458
+#: templates/manager/wordpress.html:1500
 msgid "Saving update preferences... Please wait."
-msgstr "Guardando preferencias de actualización... Por favor aguarde."
+msgstr ""
 
-#: templates/websites.html:522
+#: templates/manager/wordpress.html:1555
 msgid "Saving general settings... Please wait."
-msgstr "Guardando ajustes generales... Por favor aguarde."
+msgstr ""
 
-#: templates/websites.html:619
+#: templates/manager/wordpress.html:1625
+msgid "Error fetching debug info. Refresh the page."
+msgstr ""
+
+#: templates/manager/wordpress.html:1650
 msgid ""
 "The options below allow you to manage the native WordPress debugging tools, "
 "enabling and disabling these tools in the wp-config.php file. It is not "
 "recommended to use these options on production websites since they are meant "
 "for development and test installations. Refer to"
 msgstr ""
-"Las siguientes opciones le permiten gestionar las herramientas de depuración "
-"nativas de WordPress, activando y desactivando estas herramientas en el "
-"archivo wp-config.php. No se recomienda utilizar estas opciones en sitios "
-"web de producción, ya que están pensadas para instalaciones de desarrollo y "
-"prueba. Consulte el artículo"
 
-#: templates/websites.html:619
+#: templates/manager/wordpress.html:1650
 msgid "Debugging in WordPress"
-msgstr "Depuración en WordPress"
+msgstr ""
 
-#: templates/websites.html:619
+#: templates/manager/wordpress.html:1650
 msgid "article for more information on these options."
-msgstr "para obtener más información sobre estas opciones."
+msgstr ""
 
-#: templates/websites.html:629
+#: templates/manager/wordpress.html:1667 templates/manager/wordpress.html:1674
 msgid "WP_DEBUG"
-msgstr "WP_DEBUG"
+msgstr ""
 
-#: templates/websites.html:633
-msgid "Enable the main debug mode in WordPress"
-msgstr "Activar el modo de depuración principal en WordPress"
+#: templates/manager/wordpress.html:1668
+msgid "WordPress debug mode."
+msgstr ""
 
-#: templates/websites.html:639
+#: templates/manager/wordpress.html:1677
+msgid "Enable WP_DEBUG mode"
+msgstr ""
+
+#: templates/manager/wordpress.html:1695 templates/manager/wordpress.html:1702
 msgid "WP_DEBUG_LOG"
-msgstr "WP_DEBUG_LOG"
+msgstr ""
 
-#: templates/websites.html:643
+#: templates/manager/wordpress.html:1696
 msgid "Save all errors to the debug.log file inside the wp-content directory."
 msgstr ""
-"Guarde todos los errores en el archivo debug.log dentro del directorio wp-"
-"content."
 
-#: templates/websites.html:649
+#: templates/manager/wordpress.html:1705
+msgid "Enable WP_DEBUG_LOG"
+msgstr ""
+
+#: templates/manager/wordpress.html:1721 templates/manager/wordpress.html:1728
 msgid "WP_DEBUG_DISPLAY"
-msgstr "WP_DEBUG_DISPLAY"
+msgstr ""
 
-#: templates/websites.html:653
+#: templates/manager/wordpress.html:1722
 msgid "Show debug messages inside the HTML pages"
-msgstr "Mostrar mensajes de depuración dentro de las páginas HTML"
+msgstr ""
 
-#: templates/websites.html:659
+#: templates/manager/wordpress.html:1731
+msgid "Enable WP_DEBUG_DISPLAY"
+msgstr ""
+
+#: templates/manager/wordpress.html:1747 templates/manager/wordpress.html:1754
 msgid "SCRIPT_DEBUG"
-msgstr "SCRIPT_DEBUG"
+msgstr ""
 
-#: templates/websites.html:663
+#: templates/manager/wordpress.html:1748
 msgid ""
 "Force WordPress to use the non-minified versions of core CSS and JavaScript "
 "files. This is useful when you are testing changes made to .js and .css "
 "files."
 msgstr ""
-"Forzar a WordPress a utilizar las versiones no minificadas de los archivos "
-"CSS y JavaScript principales. Esto es útil para probar los cambios "
-"realizados en los archivos .js y .css."
 
-#: templates/websites.html:669
+#: templates/manager/wordpress.html:1757
+msgid "Enable SCRIPT_DEBUG"
+msgstr ""
+
+#: templates/manager/wordpress.html:1773 templates/manager/wordpress.html:1780
 msgid "SAVEQUERIES"
-msgstr "SAVEQUERIES"
+msgstr ""
 
-#: templates/websites.html:673
+#: templates/manager/wordpress.html:1774
 msgid ""
 "Save database queries to an array that can be displayed to help analyze them."
 msgstr ""
-"Guarde las consultas de la base de datos en una matriz que pueda "
-"visualizarse para ayudar a analizarlas."
 
-#: templates/websites.html:679
-msgid "Save Debug Options"
-msgstr "Guardar opciones de depuración"
+#: templates/manager/wordpress.html:1783
+msgid "Enable SAVEQUERIES"
+msgstr ""
 
-#: templates/websites.html:696
+#: templates/manager/wordpress.html:1796
+msgid "Save Debugging"
+msgstr ""
+
+#: templates/manager/wordpress.html:1817
 msgid "Saving debugging options... Please wait."
-msgstr "Guardando opciones de depuración... Por favor aguarde."
-
-#: templates/websites.html:753
-msgid "Security Measures"
-msgstr "Medidas de seguridad"
-
-#: templates/websites.html:767
-msgid "Restrict access to files and directories"
-msgstr "Restringir acceso a archivos y directorios"
-
-#: templates/websites.html:773 templates/websites.html:792
-#: templates/websites.html:812 templates/websites.html:832
-#: templates/websites.html:852 templates/websites.html:872
-#: templates/websites.html:892 templates/websites.html:912
-#: templates/websites.html:932 templates/websites.html:952
-#: templates/websites.html:972 templates/websites.html:991
-#: templates/websites.html:1011 templates/websites.html:1031
-#: templates/websites.html:1051 templates/websites.html:1071
-#: templates/websites.html:1091 templates/websites.html:1110
-msgid "STATUS"
-msgstr "ESTADO"
-
-#: templates/websites.html:786
-msgid "Configure security keys"
-msgstr "Configurar llaves de seguridad"
-
-#: templates/websites.html:805
-msgid "Block access to"
-msgstr "Bloquear acceso a"
-
-#: templates/websites.html:806 templates/websites.html:826
-#: templates/websites.html:846 templates/websites.html:866
-#: templates/websites.html:886 templates/websites.html:906
-#: templates/websites.html:926 templates/websites.html:946
-#: templates/websites.html:966 templates/websites.html:1005
-#: templates/websites.html:1025 templates/websites.html:1045
-#: templates/websites.html:1065 templates/websites.html:1085
-msgid "can be reverted"
-msgstr "puede ser revertido"
-
-#: templates/websites.html:825
-msgid "Block directory browsing"
-msgstr "Bloquear la navegación por directorios"
-
-#: templates/websites.html:845
-msgid "Forbid execution of PHP scripts in the wp-includes directory"
-msgstr "Prohibir la ejecución de scripts PHP en el directorio wp-includes"
-
-#: templates/websites.html:865
-msgid "Forbid execution of PHP scripts in the wp-content/uploads directory"
 msgstr ""
-"Prohibir la ejecución de scripts PHP en el directorio wp-content/uploads"
 
-#: templates/websites.html:885
-msgid "Block access to wp-config.php"
-msgstr "Bloquear el acceso a wp-config.php"
-
-#: templates/websites.html:905
-msgid "Disable scripts concatenation for WordPress admin panel"
+#: templates/manager/wordpress.html:2135
+msgid "Click to Purge WP Cache"
 msgstr ""
-"Desactivar la concatenación de scripts para el panel de administración de "
-"WordPress"
 
-#: templates/websites.html:925
-msgid "Turn off pingbacks"
-msgstr "Desactivar los pingbacks"
-
-#: templates/websites.html:945
-msgid "Disable PHP execution in cache directories"
-msgstr "Deshabilitar la ejecución de PHP en directorios caché"
-
-#: templates/websites.html:965
-msgid "Disable file editing in WordPress Dashboard"
-msgstr "Desactivar la edición de archivos en el panel de WordPress"
-
-#: templates/websites.html:985
-msgid "Change default database table prefix"
-msgstr "Cambiar el prefijo por defecto de la tabla de la base de datos"
-
-#: templates/websites.html:1004
-msgid "Enable bot protection"
-msgstr "Activar la protección contra bots"
-
-#: templates/websites.html:1024
-msgid "Block access to sensitive files"
-msgstr "Bloquear el acceso a archivos sensitivos"
-
-#: templates/websites.html:1044
-msgid "Block access to potentially sensitive files"
-msgstr "Bloquear el acceso a archivos potencialmente sensibles"
-
-#: templates/websites.html:1064
-msgid "Block access to .htaccess and .htpasswd"
-msgstr "Bloquear el acceso a .htaccess y .htpasswd"
-
-#: templates/websites.html:1084
-msgid "Block author scans"
-msgstr "Bloquear las exploraciones de autor"
-
-#: templates/websites.html:1104
-msgid "Change default administrator's username"
-msgstr "Cambiar el nombre de usuario del administrador por defecto"
-
-#: templates/websites.html:1180 templates/websites.html:1219
-#: templates/websites.html:2134 templates/wordpress.html:499
-#: templates/wordpress.html:645
-msgid "Login as Admin"
-msgstr "Iniciar sesión como administrador"
-
-#: templates/dashboard/dashboard.html:140 templates/partials/sidebar.html:88
-#: templates/websites.html:1260
-msgid "Files"
-msgstr "Archivos"
-
-#: templates/websites.html:1260 templates/websites.html:1280
-msgid "Calculating size..."
-msgstr "Calculando tamaño..."
-
-#: templates/websites.html:1267 templates/wordpress.html:205
-msgid "Domain:"
-msgstr "Dominio:"
-
-#: templates/websites.html:1285
-msgid "Database:"
-msgstr "Base de datos:"
-
-#: templates/websites.html:1286
-msgid "Table prefix:"
-msgstr "Prefijo de tabla:"
-
-#: templates/websites.html:1314
-msgid "Created"
-msgstr "Creado"
-
-#: templates/websites.html:1375
-msgid "Confirm Restore (Click Again)"
-msgstr "Confirmar restauración (Clic de nuevo)"
-
-#: templates/websites.html:1388
-msgid "Restoring backup... Please wait."
-msgstr "Restaurando copia de seguridad... Por favor aguarde."
-
-#: templates/websites.html:1400
-msgid "Restore request failed."
-msgstr "Solicitud de restauración fallida."
-
-#: templates/websites.html:1436
-msgid "Database and Files Backup"
-msgstr "Copia de seguridad de base de datos y archivos"
-
-#: templates/websites.html:1438
-msgid "Database Backup"
-msgstr "Copia de seguridad de base de datos"
-
-#: templates/websites.html:1440
-msgid "Files Backup"
-msgstr "Copia de seguridad de archivos"
-
-#: templates/websites.html:1442
-msgid "Unknown Backup Type"
-msgstr "Tipo de copia de seguridad desconocido"
-
-#: templates/websites.html:1471
-msgid "Generating website backup..."
-msgstr "Generando copias de seguridad del sitio web..."
-
-#: templates/websites.html:1486
-msgid "Backup request failed."
-msgstr "Solicitud de copia de seguridad fallida."
-
-#: templates/websites.html:1563
-msgid "WP version:"
-msgstr "Versión de WP:"
-
-#: templates/websites.html:1566
-msgid "NodeJS version:"
-msgstr "Versión de NodeJS:"
-
-#: templates/websites.html:1573
-msgid "PHP version:"
-msgstr "Versión de PHP:"
-
-#: templates/websites.html:1581
-msgid "MySQL version:"
-msgstr "Versión de MySQL:"
-
-#: templates/websites.html:1608 templates/websites.html:2193
-msgid "Backup"
-msgstr "Copia de seguridad"
-
-#: templates/websites.html:1617 templates/wordpress.html:479
-#: templates/wordpress.html:606
-msgid "Detach"
-msgstr "Desconectar"
-
-#: templates/websites.html:1618 templates/wordpress.html:473
-#: templates/wordpress.html:600
-msgid "Uninstall"
-msgstr "Desinstalar"
-
-#: templates/websites.html:1623
-msgid ""
-"Create a manual backup of the WordPress website's files and database for "
-"data protection."
+#: templates/manager/wordpress.html:2153
+msgid "Cache Type:"
 msgstr ""
-"Crear una copia de seguridad manual de los archivos y la base de datos del "
-"sitio web de WordPress para proteger los datos."
 
-#: templates/websites.html:1624
-msgid ""
-"Restore the website to a previous state using a previously created backup."
+#: templates/manager/wordpress.html:2205
+msgid "Error flushing cache"
 msgstr ""
-"Restaurar el sitio web a un estado anterior utilizando una copia de "
-"seguridad creada previamente."
 
-#: templates/websites.html:1625
-msgid ""
-"Remove the WordPress website from this manager without actually deleting any "
-"files or database."
+#: templates/manager/wordpress.html:2207
+msgid "Cache flushed successfully!"
 msgstr ""
-"Eliminar el sitio web WordPress de este administrador sin borrar realmente "
-"ningún archivo o base de datos."
 
-#: templates/websites.html:1626
-msgid ""
-"Completely remove the WordPress website, including its files, database, and "
-"records from this manager."
+#: templates/manager/wordpress.html:2212
+msgid "Failed to flush cache"
 msgstr ""
-"Eliminar completamente el sitio web WordPress, incluyendo sus archivos, base "
-"de datos y registros de este administrador."
 
-#: templates/websites.html:1675
-msgid "Expires on:"
-msgstr "Expira el:"
+#: templates/manager/wordpress.html:2307
+msgid "MariaDB version:"
+msgstr ""
 
-#: templates/websites.html:1675
-msgid "Valid SSL"
-msgstr "SSL válido"
-
-#: templates/websites.html:1677
-msgid "SSL not detected"
-msgstr "SSL no detectado"
-
-#: templates/websites.html:1741
+#: templates/manager/wordpress.html:2371
 msgid "Update in progress..."
-msgstr "Actualización en progreso..."
+msgstr ""
 
-#: templates/websites.html:1757
+#: templates/manager/wordpress.html:2378
 msgid "WordPress updated successfully."
-msgstr "WordPress se ha actualizado correctamente."
+msgstr ""
 
-#: templates/websites.html:1939
-msgid "Checking SSL status.."
-msgstr "Verificando estado de SSL..."
+#: templates/manager/wordpress.html:2441
+msgid "An error occurred fetching Cache Type from WP-CLI."
+msgstr ""
 
-#: templates/websites.html:1965
-msgid "Login as admin"
-msgstr "Iniciar sesión como admin"
+#: templates/manager/wordpress.html:2591
+msgid "Database and Files Backup"
+msgstr ""
 
-#: templates/websites.html:2054
-msgid "Cronjobs"
-msgstr "CronJobs"
+#: templates/manager/wordpress.html:2593
+msgid "Database Backup"
+msgstr ""
 
-#: templates/websites.html:2082 templates/wordpress.html:706
-msgid "An error occurred while removing WordPress."
-msgstr "Se ha producido un error al eliminar WordPress."
+#: templates/manager/wordpress.html:2597
+msgid "Unknown Backup Type"
+msgstr ""
 
-#: templates/websites.html:2101 templates/wordpress.html:725
-msgid "An error occurred while detaching WordPress."
-msgstr "Se ha producido un error al desconectar WordPress."
-
-#: templates/websites.html:2124
-msgid "Redirecting..."
-msgstr "Redireccionando..."
-
-#: templates/websites.html:2153
-msgid "Confirm WordPress Uninstall"
-msgstr "Confirmar la desinstalación de WordPress"
-
-#: templates/websites.html:2157
+#: templates/manager/wordpress.html:2611
 msgid ""
-"Are you sure you want to permanently remove the WordPress installation for"
+"No options selected to backup. Please ensure that at least one of the "
+"Database or Files is selected."
 msgstr ""
-"¿Está seguro de que desea eliminar permanentemente la instalación de "
-"WordPress de"
 
-#: templates/websites.html:2159
-msgid "This will permanently delete all website files and the database."
+#: templates/manager/wordpress_install.html:10
+msgid "Install WordPress CMS in a few clicks."
 msgstr ""
-"Esto borrará permanentemente todos los archivos del sitio web y la base de "
-"datos."
 
-#: templates/websites.html:2163
-msgid "Confirm Uninstall"
-msgstr "Confirmar desinstalación"
+#: templates/manager/wordpress_install.html:29
+msgid "Website name:"
+msgstr ""
 
-#: templates/websites.html:2173
-msgid "Confirm WordPress Detach from WP Manager"
-msgstr "Confirmar desvinculación de WordPress de WP Manager"
-
-#: templates/websites.html:2177
-msgid "Are you sure you want to detach the WordPress installation for"
-msgstr "Está seguro de que desea separar la instalación de WordPress de"
-
-#: templates/websites.html:2177
-msgid "from the manager?"
-msgstr "de este administrador?"
-
-#: templates/websites.html:2179
+#: templates/manager/wordpress_install.html:38
 msgid ""
-"This will only remove the website from the WP Manager without affecting the "
-"files or database"
+"This is your WordPress site name — you can change it anytime from the wp-"
+"admin dashboard."
 msgstr ""
-"Esto sólo eliminará el sitio web de WP Manager sin afectar a los archivos o "
-"base de datos"
 
-#: templates/websites.html:2198
-msgid "Backup Database"
-msgstr "Copia de seguridad de la base de datos"
+#: templates/manager/wordpress_install.html:47
+msgid "My Blog"
+msgstr ""
 
-#: templates/websites.html:2202
-msgid "Backup Files"
-msgstr "Copia de seguridad de archivos"
+#: templates/manager/wordpress_install.html:53
+msgid "Description:"
+msgstr ""
 
-#: templates/websites.html:2208
-msgid "Run Backup"
-msgstr "Ejecutar copia de seguridad"
-
-#: templates/websites.html:2218
-msgid "Restore Backup"
-msgstr "Restaurar copia de seguridad"
-
-#: templates/websites.html:2222
-msgid "Select a backup date to restore"
-msgstr "Seleccionar una fecha de copia para restaurar"
-
-#: templates/wordpress.html:39
-msgid "WordPress Installation failed."
-msgstr "Error en la instalación de WordPress."
-
-#: templates/wordpress.html:47
-msgid "WordPress successfully installed."
-msgstr "WordPress se ha instalado correctamente."
-
-#: templates/wordpress.html:73
-msgid "Scanning started..."
-msgstr "El escaneo ha comenzado..."
-
-#: templates/wordpress.html:92
-msgid "No installations found."
-msgstr "No se han encontrado instalaciones."
-
-#: templates/wordpress.html:133
-msgid "Data refresh in progress..."
-msgstr "Actualización de datos en curso..."
-
-#: templates/wordpress.html:145
-msgid "Refresh completed."
-msgstr "Actualización completada."
-
-#: templates/wordpress.html:191 templates/wordpress.html:774
-msgid "Install WordPress"
-msgstr "Instalar WordPress"
-
-#: templates/wordpress.html:192
-msgid "Install WordPress on an existing domain."
-msgstr "Instalar WordPress en un dominio existente."
-
-#: templates/wordpress.html:196
-msgid "Website Name:"
-msgstr "Nombre del sitio web:"
-
-#: templates/wordpress.html:200
-msgid "Site Description:"
-msgstr "Descripción del sitio:"
-
-#: templates/wordpress.html:221
-msgid "Admin Email:"
-msgstr "Email del admin:"
-
-#: templates/wordpress.html:275
-msgid "Admin Username:"
-msgstr "Usuario del admin:"
-
-#: templates/wordpress.html:279
-msgid "Admin Password:"
-msgstr "Contraseña del admin:"
-
-#: templates/wordpress.html:371
-msgid "Start Installation"
-msgstr "Iniciar instalación"
-
-#: templates/wordpress.html:421
-msgid "Error fetching versions"
-msgstr "Error en la búsqueda de versiones"
-
-#: templates/wordpress.html:454
-msgid "WordPress Version"
-msgstr "Versión de WordPress"
-
-#: templates/wordpress.html:456
-msgid "Created on"
-msgstr "Creado el"
-
-#: templates/wordpress.html:471 templates/wordpress.html:598
-msgid "Delete WordPress website"
-msgstr "Eliminar sitio WordPress"
-
-#: templates/wordpress.html:472 templates/wordpress.html:599
+#: templates/manager/wordpress_install.html:62
 msgid ""
-"This will irreversibly delete the website, permanently deleting all files "
-"and database."
+"This is your WordPress site description (tagline) — it is optional and you "
+"can change it anytime from the wp-admin dashboard."
 msgstr ""
-"Esto eliminará irreversiblemente el sitio web, borrando definitivamente "
-"todos los archivos y la base de datos."
 
-#: templates/wordpress.html:477 templates/wordpress.html:604
-msgid "Remove from WP Manager"
-msgstr "Remover de WP Manager"
+#: templates/manager/wordpress_install.html:69
+msgid "My WordPress Blog"
+msgstr ""
 
-#: templates/wordpress.html:478 templates/wordpress.html:605
+#: templates/manager/wordpress_install.html:89
 msgid ""
-"This will just remove the installation from WP Manager but keep the files "
-"and database."
+"Users will access your website through this domain. If a subfolder is "
+"provided, it will be available at example.com/subfolder instead of "
+"example.com"
 msgstr ""
-"Esto sólo eliminará la instalación de WP Manager pero mantendrá los archivos "
-"y la base de datos."
 
-#: templates/wordpress.html:500 templates/wordpress.html:632
-msgid "Manage"
-msgstr "Gestionar"
-
-#: templates/wordpress.html:771
-msgid "No WordPress Installations"
-msgstr "No hay instalaciones de WordPress"
-
-#: templates/wordpress.html:772
+#: templates/manager/wordpress_install.html:128
 msgid ""
-"There are no existing WordPress installations. You can install a new "
-"instance below."
+"The WordPress admin email address for notifications and site management. It "
+"can be updated later in the wp-admin dashboard."
 msgstr ""
-"No existen instalaciones de WordPress. Puede instalar una nueva instancia a "
-"continuación."
 
-#: templates/domains/domains.html:552 templates/wordpress.html:776
-msgid "or"
-msgstr "o"
-
-#: templates/wordpress.html:778
-msgid "Scan for existing Installations"
-msgstr "Buscar instalaciones existentes"
-
-#: templates/wordpress.html:793
-msgid "Add a domain name first in order to install WordPress."
-msgstr "Agregue primero un dominio para poder instalar WordPress."
-
-#: templates/wordpress.html:824
-msgid "Refresh"
-msgstr "Actualizar"
-
-#: templates/wordpress.html:824
-msgid "Data"
-msgstr "Datos"
-
-#: templates/wordpress.html:832
-msgid "Scan"
-msgstr "Escanear"
-
-#: templates/wordpress.html:836
-msgid "Switch to List View - perfect for those with many Websites."
-msgstr ""
-"Cambiar a vista de lista: perfecto para quienes tienen muchos sitios web."
-
-#: templates/wordpress.html:839
+#: templates/manager/wordpress_install.html:200
 msgid ""
-"Switch to Grid View - a visual representation of your Websites and their "
-"content."
+"This is your WordPress admin username — used to log in to the wp-admin "
+"dashboard."
 msgstr ""
-"Cambiar a la vista de cuadrícula: una representación visual de sus sitios "
-"web y su contenido."
 
-#: templates/dashboard/dashboard.html:62
-msgid "👋 Welcome to your new hosting account. OpenPanel is here to help!"
-msgstr ""
-"👋 Bienvenido/a a su nueva cuenta de hosting. ¡OpenPanel está aquí para "
-"ayudarle!"
-
-#: templates/dashboard/dashboard.html:63
+#: templates/manager/wordpress_install.html:233
 msgid ""
-"To get started, add a domain name to create a new site and unlock a world of "
-"possibilities for your online presence."
+"Your WordPress admin password — used to access the dashboard. Keep it "
+"secure, and you can change it anytime from the wp-admin dashboard."
 msgstr ""
-"Para empezar, agregue un dominio para crear un nuevo sitio y desbloquear un "
-"mundo de posibilidades para su presencia en línea."
 
-#: templates/dashboard/dashboard.html:66
+#: templates/manager/wordpress_install.html:401
+msgid "WordPress version:"
+msgstr ""
+
+#: templates/manager/wordpress_install.html:410
 msgid ""
-"To secure your website with a free Let's Encrypt SSL, make sure your "
-"domain's A record is pointed to your dedicated IP address:"
+"Select the WordPress version to install — you can choose the latest stable "
+"release or a specific version."
 msgstr ""
-"Para proteger tu sitio web con un SSL gratuito de Let's Encrypt, asegúrese "
-"de que el registro A de su dominio apunte a su dirección IP dedicada:"
 
-#: templates/dashboard/dashboard.html:66 templates/dashboard/dashboard.html:68
-msgid "Ready to start?"
-msgstr "¿Preparado/a para empezar?"
+#: templates/manager/wordpress_install.html:499
+msgid "The name of the MySQL database where WordPress will store its data."
+msgstr ""
 
-#: templates/dashboard/dashboard.html:68
+#: templates/manager/wordpress_install.html:521
 msgid ""
-"To secure your website with a free Let's Encrypt SSL, make sure your "
-"domain's A record is pointed to the server IP address:"
+"The prefix for WordPress database tables. Use the default \"wp_\" or choose "
+"a custom prefix for added security."
 msgstr ""
-"Para proteger su sitio web con un SSL gratuito de Let's Encrypt, asegúrese "
-"de que el registro A de su dominio apunta a la dirección IP del servidor:"
 
-#: templates/dashboard/dashboard.html:70
-msgid "Add a new domain"
-msgstr "Agregue un nuevo dominio"
-
-#: templates/dashboard/dashboard.html:109 templates/partials/sidebar.html:68
-msgid "Applications"
-msgstr "Aplicaciones"
-
-#: templates/dashboard/dashboard.html:128 templates/partials/sidebar.html:84
-msgid "NodeJS & Python"
-msgstr "NodeJs y Python"
-
-#: templates/dashboard/dashboard.html:154
-msgid "FTP Accounts"
-msgstr "Cuentas FTP"
-
-#: templates/dashboard/dashboard.html:169 templates/partials/sidebar.html:100
-msgid "Backup & Restore"
-msgstr "Copia de seguridad y Restauración"
-
-#: templates/dashboard/dashboard.html:185 templates/partials/sidebar.html:108
-msgid "ClamAV Scanner"
-msgstr "Escaner ClamAV"
-
-#: templates/dashboard/dashboard.html:218 templates/partials/sidebar.html:180
-msgid "DNS Zone Editor"
-msgstr "Editor de zona DNS"
-
-#: templates/dashboard/dashboard.html:224 templates/partials/sidebar.html:187
-msgid "SSL Certificates"
-msgstr "Certificados SSL"
-
-#: templates/dashboard/dashboard.html:231
-msgid "Access Logs"
-msgstr "Registros de acceso"
-
-#: templates/dashboard/dashboard.html:261
-msgid "PHPMyAdmin"
-msgstr "phpMyAdmin"
-
-#: templates/dashboard/dashboard.html:269 templates/partials/sidebar.html:165
-msgid "Show Processes"
-msgstr "Mostrar procesos"
-
-#: templates/dashboard/dashboard.html:286
-msgid "Search & Caching"
-msgstr "Búsqueda y caché"
-
-#: templates/dashboard/dashboard.html:322 templates/partials/sidebar.html:281
-#: templates/system/services_status.html:147
-msgid "ElasticSearch"
-msgstr "ElasticSearch"
-
-#: templates/dashboard/dashboard.html:358
-msgid "Install new version"
-msgstr "Instalar nueva versión"
-
-#: templates/dashboard/dashboard.html:365
-msgid "PHP extensions"
-msgstr "Extensiones PHP"
-
-#: templates/dashboard/dashboard.html:372
-msgid "PHP options"
-msgstr "Opciones PHP"
-
-#: templates/dashboard/dashboard.html:385 templates/partials/sidebar.html:312
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: templates/dashboard/dashboard.html:417 templates/partials/sidebar.html:342
-msgid "Web Terminal"
-msgstr "Terminal Web"
-
-#: templates/dashboard/dashboard.html:443 templates/system/general.html:19
-msgid "Change TimeZone"
-msgstr "Cambiar zona horaria"
-
-#: templates/dashboard/dashboard.html:450 templates/system/general.html:73
-msgid "MySQL Configuration"
-msgstr "Configuración MySQL"
-
-#: templates/dashboard/dashboard.html:458
-msgid "Webserver Configuration"
-msgstr "Configuración de servidor web"
-
-#: templates/dashboard/dashboard.html:495 templates/user/account.html:12
-#: templates/user/activity.html:116 templates/user/loginlog.html:11
-#: templates/user/twofa_settings.html:10
-msgid "Account"
-msgstr "Cuenta"
-
-#: templates/dashboard/dashboard.html:505
-msgid "Password & Security"
-msgstr "Contraseña y seguridad"
-
-#: templates/dashboard/dashboard.html:512
-#: templates/dashboard/dashboard.html:548 templates/user/twofa_settings.html:25
-msgid "Two-Factor Authentication"
-msgstr "Autenticación de dos factores"
-
-#: templates/dashboard/dashboard.html:519 templates/partials/sidebar.html:305
-msgid "Account Activity"
-msgstr "Actividad de la cuenta"
-
-#: templates/dashboard/dashboard.html:556
+#: templates/manager/wordpress_install.html:543
 msgid ""
-"2FA is an added layer of security that significantly reduces the risk of "
-"unauthorized access to your account by requiring an additional verification "
-"step beyond just a password"
+"The MySQL username with access to the database. WordPress will use this "
+"account to read and write data."
 msgstr ""
-"2FA es una capa adicional de seguridad que reduce significativamente el "
-"riesgo de acceso no autorizado a su cuenta al requerir un paso adicional de "
-"verificación más allá de una simple contraseña"
 
-#: templates/dashboard/dashboard.html:560
-msgid "2FA is <b>enabled</b> for your account."
-msgstr "2FA está <b>activado</b> para su cuenta."
-
-#: templates/dashboard/dashboard.html:562 templates/user/twofa_settings.html:39
-msgid "Click to disable 2FA"
-msgstr "Clic para desactivar 2FA"
-
-#: templates/dashboard/dashboard.html:565
-msgid "2FA is <b>disabled</b> for your account."
-msgstr "2FA está <b>desactivado</b> para su cuenta."
-
-#: templates/dashboard/dashboard.html:569 templates/user/twofa_settings.html:48
-#: templates/user/twofa_settings.html:50
-msgid "Enable 2FA"
-msgstr "Activar 2FA"
-
-#: templates/dashboard/dashboard.html:571
-msgid "Click to Enable"
-msgstr "Clic para activar"
-
-#: templates/dashboard/dashboard.html:583
-msgid "Server Information & Statistics"
-msgstr "Información y estadísticas del servidor"
-
-#: templates/dashboard/dashboard.html:593
-msgid "Dedicated IP Address"
-msgstr "Dirección IP dedicada"
-
-#: templates/dashboard/dashboard.html:595
-msgid "Server IP Address"
-msgstr "Dirección IP del servidor"
-
-#: templates/dashboard/dashboard.html:599
-msgid "Last Login IP Address"
-msgstr "Dirección IP del último acceso"
-
-#: templates/dashboard/dashboard.html:649
-msgid "Nameservers"
-msgstr "Servidores de nombres"
-
-#: templates/dashboard/dashboard.html:669
-#: templates/dashboard/dashboard.html:673
-msgid "Websites:"
-msgstr "Sitios web:"
-
-#: templates/dashboard/dashboard.html:669
-#: templates/dashboard/dashboard.html:690
-#: templates/dashboard/dashboard.html:711
-msgid "∞"
-msgstr "∞"
-
-#: templates/dashboard/dashboard.html:690
-#: templates/dashboard/dashboard.html:693
-msgid "Domains:"
-msgstr "Dominios:"
-
-#: templates/dashboard/dashboard.html:708
+#: templates/manager/wordpress_install.html:567
 msgid ""
-"The number of MySQL, PostgreSQL or MongoDB databases you can have on the "
-"current hosting plan."
+"The password for the MySQL user. Keep it secure, as it is required for "
+"WordPress to connect to the database."
 msgstr ""
-"El número de bases de datos MySQL, PostgreSQL o MongoDB que puede tener en "
-"el plan de alojamiento actual."
 
-#: templates/dashboard/dashboard.html:711
-#: templates/dashboard/dashboard.html:715
-msgid "Databases:"
-msgstr "Bases de datos:"
+#: templates/manager/wordpress_install.html:649
+msgid "WordPress install started. Please wait for the process to finish."
+msgstr ""
 
-#: templates/dashboard/dashboard.html:738
+#: templates/manager/wordpress_install.html:762
+msgid "Error fetching WordPress versions from WP.ORG API. Please refresh page."
+msgstr ""
+
+#: templates/mysql/assign.html:11
 msgid ""
-"Disk usage refers to the amount of storage space occupied by files, "
-"databases, emails, and other data associated with your account."
+"Assign a user to an existing MySQL database to manage database permissions "
+"and enable access for executing queries, modifying tables, or managing data "
+"within the specified database."
 msgstr ""
-"El uso de disco se refiere a la cantidad de espacio de almacenamiento "
-"ocupado por archivos, bases de datos, correos electrónicos y otros datos "
-"asociados a su cuenta."
 
-#: templates/dashboard/dashboard.html:741
-msgid "Disk Usage:"
-msgstr "Uso de disco:"
+#: templates/mysql/assign.html:26 templates/mysql/remove.html:25
+#: templates/psql/assign.html:26 templates/psql/remove.html:25
+msgid "Select user:"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:742
-#: templates/dashboard/dashboard.html:765
-msgid "Calculating.."
-msgstr "Calculando..."
+#: templates/mysql/assign.html:39 templates/mysql/import.html:25
+#: templates/mysql/remove.html:37 templates/psql/assign.html:39
+#: templates/psql/import.html:22 templates/psql/remove.html:37
+msgid "Select database:"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:761
+#: templates/mysql/assign.html:41 templates/mysql/processlist.html:59
+#: templates/mysql/remove.html:39 templates/psql/assign.html:41
+#: templates/psql/remove.html:39
+msgid "Host"
+msgstr ""
+
+#: templates/mysql/assign.html:63 templates/mysql/import.html:55
+#: templates/mysql/new.html:50 templates/mysql/remove.html:60
+#: templates/mysql/root_password.html:157 templates/mysql/wizard.html:194
+#: templates/psql/assign.html:66 templates/psql/import.html:52
+#: templates/psql/new.html:50 templates/psql/remove.html:60
+#: templates/psql/wizard.html:194
+msgid "Back to Databases"
+msgstr ""
+
+#: templates/mysql/configuration.html:14
 msgid ""
-"The number of inodes indicates the number of files and folders you have. "
-"This includes everything on your account, emails, files, folders, and "
-"anything you store on the server."
+"View and modify the MySQL service configuration. Any changes will restart "
+"the service."
 msgstr ""
-"El número de inodes indica el número de archivos y carpetas que tiene. Esto "
-"incluye todo lo que hay en su cuenta, correos electrónicos, archivos, "
-"carpetas y cualquier cosa que almacene en el servidor."
 
-#: templates/dashboard/dashboard.html:764
-msgid "Inodes:"
-msgstr "Inodes:"
+#: templates/mysql/configuration.html:14
+msgid "For more information"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:886
-#: templates/dashboard/dashboard.html:906 templates/system/server_info.html:15
-#: templates/system/server_info.html:24 templates/system/server_info.html:32
-#: templates/system/server_info.html:43 templates/system/server_info.html:64
-#: templates/system/server_info.html:74 templates/system/server_info.html:83
-#: templates/system/server_info.html:92
-msgid "Loading..."
-msgstr "Cargando..."
+#: templates/mysql/configuration.html:14
+msgid "read the documentation"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:906
-msgid "Memory Usage:"
-msgstr "Uso de memoria:"
+#: templates/mysql/configuration.html:48 templates/php/limits.html:50
+#: templates/psql/configuration.html:48
+msgid "Setting"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:990
-msgid "General How-to"
-msgstr "Instrucciones generales"
+#: templates/mysql/configuration.html:49 templates/php/options.html:50
+#: templates/psql/configuration.html:49
+msgid "Value"
+msgstr ""
 
-#: templates/dashboard/dashboard.html:1002
-msgid "Visit KnowledgeBase"
-msgstr "Visitar base de conocimiento"
+#: templates/mysql/databases.html:8
+msgid "MySQL Databases"
+msgstr ""
 
-#: templates/domains/domains.html:102
-msgid "Domain Name:"
-msgstr "Dominio:"
-
-#: templates/domains/domains.html:109
-msgid "Document Root (folder):"
-msgstr "Raíz del documento (carpeta):"
-
-#: templates/domains/domains.html:113
+#: templates/mysql/databases.html:13
 msgid ""
-"*Document root for now can not be changed, but this feature will soon be "
-"added."
+"For connecting to database do not use localhost or 127.0.0.1, instead use:"
 msgstr ""
-"*La raíz del documento por ahora no se puede cambiar, pero esta función se "
-"incorporará pronto."
 
-#: templates/domains/domains.html:131
+#: templates/mysql/databases.html:15
+msgid "server:"
+msgstr ""
+
+#: templates/mysql/databases.html:16
+msgid "port:"
+msgstr ""
+
+#: templates/mysql/databases.html:21 templates/psql/databases.html:11
+msgid "Total databases:"
+msgstr ""
+
+#: templates/mysql/databases.html:29 templates/psql/databases.html:18
+msgid "Show system databases"
+msgstr ""
+
+#: templates/mysql/databases.html:33 templates/psql/databases.html:22
+msgid "Size in:"
+msgstr ""
+
+#: templates/mysql/databases.html:134 templates/psql/databases.html:123
+msgid "New Database"
+msgstr ""
+
+#: templates/mysql/databases.html:149 templates/mysql/import.html:40
+#: templates/mysql/new.html:23 templates/mysql/wizard.html:28
+#: templates/psql/databases.html:138 templates/psql/import.html:37
+#: templates/psql/new.html:23 templates/psql/wizard.html:28
+msgid "Database Name"
+msgstr ""
+
+#: templates/mysql/databases.html:155 templates/psql/databases.html:144
+msgid "Assigned Users"
+msgstr ""
+
+#: templates/mysql/import.html:7 templates/psql/import.html:7
+msgid "Import into Database"
+msgstr ""
+
+#: templates/mysql/import.html:9
+msgid "Select a local file to upload and import into a MySQL database."
+msgstr ""
+
+#: templates/mysql/import.html:10
+msgid "Select a local file to upload and import into a MariaDB database."
+msgstr ""
+
+#: templates/mysql/import.html:42 templates/psql/import.html:39
+msgid "Select file to upload"
+msgstr ""
+
+#: templates/mysql/mysql_user.html:11
+msgid "Create MySQL User"
+msgstr ""
+
+#: templates/mysql/mysql_user.html:12
 msgid ""
-"When you create a domain or subdomain, the system will attempt to secure "
-"that domain with a free"
+"Create a new MySQL user with a unique username and password to securely "
+"manage access and permissions for interacting with databases or the MySQL "
+"server."
 msgstr ""
-"Al crear un dominio o subdominio, el sistema intentará asegurar ese dominio "
-"con un"
 
-#: templates/domains/domains.html:131
-msgid "certificate."
-msgstr "certificado gratuito."
+#: templates/mysql/mysql_user.html:29 templates/psql/mysql_user.html:29
+#: templates/psql/psql_user.html:23
+msgid "Random Username"
+msgstr ""
 
-#: templates/domains/domains.html:133 templates/domains/domains.html:483
-msgid "Add Domain"
-msgstr "Agregar dominio"
+#: templates/mysql/mysql_user.html:169 templates/mysql/password.html:170
+#: templates/psql/mysql_user.html:66 templates/psql/password.html:164
+#: templates/psql/psql_user.html:163
+msgid "Back to Users"
+msgstr ""
 
-#: templates/domains/domains.html:143
-msgid "Display: "
-msgstr "Mostrar: "
+#: templates/mysql/new.html:7 templates/psql/new.html:7
+msgid "Create a Database"
+msgstr ""
 
-#: templates/domains/domains.html:143
-msgid " Name"
-msgstr " Nombre"
-
-#: templates/domains/domains.html:144
-msgid " DNS Zone"
-msgstr " Zona DNS"
-
-#: templates/domains/domains.html:145
-msgid " Redirect"
-msgstr " Redireccionar"
-
-#: templates/domains/domains.html:154 templates/domains/domains.html:321
-msgid "Showing domains"
-msgstr "Mostrando dominios"
-
-#: templates/domains/domains.html:154 templates/domains/domains.html:321
-msgid "to"
-msgstr "a"
-
-#: templates/domains/domains.html:154 templates/domains/domains.html:321
-msgid "from a total of"
-msgstr "de un total de"
-
-#: templates/domains/domains.html:159 templates/domains/domains.html:326
-msgid "Page navigation"
-msgstr "Navegación de la página"
-
-#: templates/domains/domains.html:163 templates/domains/domains.html:330
-#: templates/domains/domains.html:331
-msgid "Previous"
-msgstr "Anterior"
-
-#: templates/domains/domains.html:164
-msgid " Previous"
-msgstr " Anterior"
-
-#: templates/domains/domains.html:185 templates/domains/domains.html:186
-#: templates/domains/domains.html:352 templates/domains/domains.html:353
-msgid "Next"
-msgstr "Siguiente"
-
-#: templates/domains/domains.html:202
-msgid "Domain Name"
-msgstr "Dominio"
-
-#: templates/domains/domains.html:203
+#: templates/mysql/new.html:8
 msgid ""
-"The document root refers to the directory where the content of a domain name "
-"is displayed from. It serves as the designated folder where website files "
-"should be stored."
+"Create a new MySQL database to store and organize data, providing a "
+"foundational structure for applications to manage and retrieve information "
+"efficiently."
 msgstr ""
-"La raíz del documento se refiere al directorio desde donde se muestra el "
-"contenido de un dominio. Sirve como la carpeta designada donde se deben "
-"almacenar los archivos del sitio web."
 
-#: templates/domains/domains.html:203
-msgid "Document Root"
-msgstr "Raíz del documento"
+#: templates/mysql/new.html:25 templates/psql/new.html:25
+msgid "Random Database Name"
+msgstr ""
 
-#: templates/domains/domains.html:205
+#: templates/mysql/password.html:10 templates/psql/password.html:10
+msgid "Change User Password"
+msgstr ""
+
+#: templates/mysql/password.html:11
+msgid "Change password for a MySQL database user."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:15 templates/mysql/phpmyadmin.html:50
+msgid "Enable/disable phpMyAdmin service."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:25
+msgid "Open phpMyAdmin Login"
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:114
+msgid "PHP limits for the phpMyAdmin container."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:121
+msgid "Max execution time:"
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:129
+msgid "Upload limit:"
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:157
+msgid "Custom link for accessing the phpMyAdmin service."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:162
+msgid "Link:"
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:175 templates/psql/pgadmin.html:159
+#: templates/system/ssh.html:62
+msgid "Port"
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:176
+msgid "IP and Port for accessing the phpMyAdmin service."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:203
+msgid "View phpMyAdmin service logs."
+msgstr ""
+
+#: templates/mysql/phpmyadmin.html:209 templates/psql/pgadmin.html:192
+msgid "View container log"
+msgstr ""
+
+#: templates/mysql/processlist.html:9
+msgid "MySQL Processes"
+msgstr ""
+
+#: templates/mysql/processlist.html:10
 msgid ""
-"Within the DNS zone, you have the capability to create or oversee various "
-"records, including but not limited to A, AAAA, MX, TXT, and more."
+"List of all current processes running on the MySQL server, providing "
+"insights into ongoing queries, operations, and their associated details for "
+"better performance monitoring."
 msgstr ""
-"Dentro de la zona DNS, usted tiene la capacidad de crear o supervisar varios "
-"registros, incluyendo pero no limitado a A, AAAA, MX, TXT, y más."
 
-#: templates/domains/domains.html:205
-msgid "DNS"
-msgstr "DNS"
+#: templates/mysql/processlist.html:40 templates/system/process_manager.html:40
+msgid "Refresh Processes"
+msgstr ""
 
-#: templates/domains/domains.html:205
-msgid " Zone"
-msgstr " Zona"
+#: templates/mysql/processlist.html:53
+msgid "ID"
+msgstr ""
 
-#: templates/domains/domains.html:206
+#: templates/mysql/processlist.html:56 templates/user/activity.html:44
+msgid "User"
+msgstr ""
+
+#: templates/mysql/processlist.html:62
+msgid "DB"
+msgstr ""
+
+#: templates/mysql/processlist.html:65 templates/system/cronjobs.html:137
+msgid "Command"
+msgstr ""
+
+#: templates/mysql/processlist.html:68
+msgid "Time"
+msgstr ""
+
+#: templates/mysql/processlist.html:71 templates/psql/processlist.html:326
+msgid "State"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:14
+msgid "Remote MySQL Access"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:15
 msgid ""
-"Here, you have the option to redirect traffic to a different URL. Once "
-"activated, all query parameters will be transmitted to the specified url."
+"Enable remote access to connect to a MySQL database on this server from a "
+"another (remote) device or location over the internet."
 msgstr ""
-"Aquí tiene la opción de redirigir el tráfico a una URL diferente. Una vez "
-"activada, todos los parámetros de consulta se transmitirán a la url "
-"especificada."
 
-#: templates/domains/domains.html:207
+#: templates/mysql/remote_mysql.html:24 templates/mysql/remote_mysql.html:38
+msgid "Disable Remote MySQL Access"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:31 templates/mysql/remote_mysql.html:44
+msgid "Enable Remote MySQL Access"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:63
+msgid "Remote access to MySQL is currently:"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:118 templates/psql/remote_psql.html:116
+msgid "Remote"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:119 templates/mysql/remote_mysql.html:142
+#: templates/psql/remote_psql.html:117 templates/psql/remote_psql.html:139
+msgid "Connection info when connecting to database"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:119 templates/psql/remote_psql.html:117
+msgid "from a remote server"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:141 templates/psql/remote_psql.html:138
+msgid "Local"
+msgstr ""
+
+#: templates/mysql/remote_mysql.html:142 templates/psql/remote_psql.html:139
+msgid "from a local server"
+msgstr ""
+
+#: templates/mysql/remove.html:10 templates/psql/remove.html:10
+msgid "Remove User access from Database"
+msgstr ""
+
+#: templates/mysql/remove.html:11
 msgid ""
-"When a domain possesses SSL, Force HTTPS is activated automatically, "
-"redirecting all traffic to utilize the secure https protocol. However, if a "
-"domain lacks an SSL, Force HTTPS cannot be enabled."
+"Remove a user from an existing MySQL database to revoke their permissions "
+"and prevent access to executing queries, modifying tables, or managing data "
+"within the specified database."
 msgstr ""
-"Cuando un dominio posee SSL, Forzar HTTPS se activa automáticamente, "
-"redirigiendo todo el tráfico para utilizar el protocolo seguro https. Sin "
-"embargo, si un dominio carece de SSL, no se puede activar Forzar HTTPS."
 
-#: templates/domains/domains.html:207
-msgid "Force "
-msgstr "Forzar "
-
-#: templates/domains/domains.html:207
-msgid "HTTPS"
-msgstr "HTTPS"
-
-#: templates/domains/domains.html:228
-msgid "Edit DNS"
-msgstr "Editar DNS"
-
-#: templates/domains/domains.html:264
-msgid "Enter redirect URL"
-msgstr "Ingrese la URL de redirección"
-
-#: templates/domains/domains.html:270
-msgid "Create Redirect"
-msgstr "Crear redirección"
-
-#: templates/domains/domains.html:296
-msgid "delete-menu"
-msgstr "delete-menu"
-
-#: templates/domains/domains.html:299
-msgid " Edit VirtualHosts"
-msgstr " Editar VirtualHosts"
-
-#: templates/domains/domains.html:304
-msgid " Delete Domain"
-msgstr " Eliminar dominio"
-
-#: templates/domains/domains.html:442
-msgid "Confirm Domain Deletion"
-msgstr "Confirmar eliminación de dominio"
-
-#: templates/domains/domains.html:447
-msgid "Are you sure you want to delete the domain?"
-msgstr "¿ Está seguro de que desea eliminar el dominio?"
-
-#: templates/domains/domains.html:552
-msgid "Invalid domain name. Please enter a valid domain name like"
+#: templates/mysql/root_password.html:11
+msgid "Change MySQL root password"
 msgstr ""
-"Nombre de dominio no válido. Por favor, introduzca un nombre de dominio "
-"válido como"
 
-#: templates/domains/domains.html:561
-msgid " Adding domain..."
-msgstr " Agregando dominio..."
+#: templates/mysql/root_password.html:12
+msgid "Change MySQL root user password and restart mysql service."
+msgstr ""
 
-#: templates/domains/domains.html:563
-msgid " Generating SSL certificate..."
-msgstr " Generando certificado SSL..."
+#: templates/mysql/users.html:9
+msgid "MySQL Users"
+msgstr ""
 
-#: templates/domains/domains.html:565
-msgid "Editing Nginx configuration..."
-msgstr "Editando configuración de Nginx…"
+#: templates/mysql/users.html:10 templates/psql/users.html:10
+msgid "Total users:"
+msgstr ""
 
-#: templates/domains/domains.html:659
-msgid "Are you sure you want to delete the domain"
-msgstr "Está seguro de que desea eliminar el dominio"
+#: templates/mysql/users.html:17 templates/psql/users.html:17
+msgid "Show system users"
+msgstr ""
 
-#: templates/domains/domains.html:671
-msgid "can not be deleted because it is used on websites:"
-msgstr "no puede eliminarse porque se utiliza en sitios web:"
+#: templates/mysql/users.html:72 templates/psql/users.html:72
+msgid "Assign User"
+msgstr ""
 
-#: templates/domains/domains.html:745
-msgid "Converted to Punycode:"
-msgstr "Convertido a Punycode:"
+#: templates/mysql/users.html:74 templates/psql/users.html:74
+msgid "Remove User"
+msgstr ""
 
-#: templates/domains/domains.html:745
-msgid "(for compatibility with internationalized domain names)"
-msgstr "(para compatibilidad con nombres de dominio internacionalizados)"
+#: templates/mysql/users.html:74 templates/psql/users.html:74
+msgid "from"
+msgstr ""
 
-#: templates/domains/edit_dns_zone.html:25
+#: templates/mysql/wizard.html:9
 msgid ""
-"The DNS Zone Editor feature allows you to create, edit, and delete Domain "
-"Name System (DNS) zone records."
+"Create a new MySQL database, set up a user with a secure password, and "
+"assign it to the database with all necessary privileges."
 msgstr ""
-"La función Editor de zona DNS permite crear, editar y eliminar registros de "
-"zona del Sistema de Nombres de Dominio (DNS)."
 
-#: templates/domains/edit_dns_zone.html:109
-msgid "Search records"
-msgstr "Buscar registros"
-
-#: templates/domains/edit_dns_zone.html:115
-#: templates/domains/edit_dns_zone.html:128
-#: templates/domains/edit_dns_zone.html:255
-#: templates/domains/edit_dns_zone.html:256
-msgid "TTL"
-msgstr "TTL"
-
-#: templates/domains/edit_dns_zone.html:117
-#: templates/domains/edit_dns_zone.html:144
-#: templates/domains/edit_dns_zone.html:276
-#: templates/domains/edit_dns_zone.html:277
-msgid "Record"
-msgstr "Registro"
-
-#: templates/domains/edit_dns_zone.html:132
-msgid "A"
-msgstr "A"
-
-#: templates/domains/edit_dns_zone.html:133
-msgid "AAAA"
-msgstr "AAAA"
-
-#: templates/domains/edit_dns_zone.html:134
-msgid "CAA"
-msgstr "CAA"
-
-#: templates/domains/edit_dns_zone.html:135
-msgid "CNAME"
-msgstr "CNAME"
-
-#: templates/domains/edit_dns_zone.html:136
-msgid "MX"
-msgstr "MX"
-
-#: templates/domains/edit_dns_zone.html:137
-msgid "SRV"
-msgstr "SRV"
-
-#: templates/domains/edit_dns_zone.html:138
-msgid "TXT"
-msgstr "TXT"
-
-#: templates/domains/edit_dns_zone.html:140
-msgid "IN"
-msgstr "IN"
-
-#: templates/domains/edit_dns_zone.html:143
-#: templates/domains/edit_dns_zone.html:272
-#: templates/domains/edit_dns_zone.html:273
-msgid "Priority"
-msgstr "Prioridad"
-
-#: templates/domains/edit_dns_zone.html:148
-#: templates/domains/edit_dns_zone.html:281
-msgid "Save Record"
-msgstr "Guardar registro"
-
-#: templates/domains/edit_dns_zone.html:162
-#: templates/domains/edit_dns_zone.html:165
-#: templates/domains/edit_dns_zone.html:300
-msgid "Address"
-msgstr "Dirección"
-
-#: templates/domains/edit_dns_zone.html:212
-msgid " Edit"
-msgstr " Editar"
-
-#: templates/domains/edit_dns_zone.html:216
-#: templates/domains/edit_dns_zone.html:474
-msgid " Save"
-msgstr " Guardar"
-
-#: templates/domains/edit_dns_zone.html:220
-#: templates/domains/edit_dns_zone.html:475
-msgid " Cancel"
-msgstr " Cancelar"
-
-#: templates/domains/edit_dns_zone.html:245
-msgid "Add DNS Record"
-msgstr "Agregar registro DNS"
-
-#: templates/domains/edit_dns_zone.html:297
-msgid "IPv4 Address"
-msgstr "Dirección IPv4"
-
-#: templates/domains/edit_dns_zone.html:350
-msgid "Add Record"
-msgstr "Agregar registro"
-
-#: templates/domains/edit_dns_zone.html:354 templates/partials/sidebar.html:44
-msgid "Add"
-msgstr "Agregar"
-
-#: templates/domains/edit_dns_zone.html:362
-msgid ""
-"DNS Zone Editor allows you to manage and edit Domain Name System (DNS) zone "
-"files, which contain critical information for mapping domain names to IP "
-"addresses and managing various DNS records, such as A, CNAME, MX, and TXT "
-"records."
+#: templates/mysql/wizard.html:23 templates/psql/wizard.html:23
+msgid "Create a database"
 msgstr ""
-"El Editor de Zonas DNS le permite gestionar y editar archivos de zona del "
-"Sistema de Nombres de Dominio (DNS), que contienen información crítica para "
-"asignar nombres de dominio a direcciones IP y gestionar varios registros "
-"DNS, como los registros A, CNAME, MX y TXT."
 
-#: templates/domains/edit_dns_zone.html:367
-msgid "Select domain:"
-msgstr "Seleccione dominio:"
-
-#: templates/domains/edit_dns_zone.html:369
-msgid "Select a domain name to edit DNS Zone"
-msgstr "Seleccione un dominio para editar la Zona DNS"
-
-#: templates/domains/edit_dns_zone.html:421
-msgid " Delete"
-msgstr " Eliminar"
-
-#: templates/error_pages/404.html:7
-msgid "404 Error Page"
-msgstr "Página de error 404"
-
-#: templates/error_pages/404.html:14
-msgid "Opps!"
-msgstr "¡Ups!"
-
-#: templates/error_pages/404.html:14
-msgid "Page not found."
-msgstr "Página no encontrada."
-
-#: templates/error_pages/404.html:15
-msgid "The page you’re looking for doesn’t exist."
-msgstr "La página que está buscando no existe."
-
-#: templates/error_pages/404.html:16
-msgid "Go Home"
-msgstr "Ir al inicio"
-
-#: templates/error_pages/500.html:7
-msgid "500 Error Page"
-msgstr "Página de error 500"
-
-#: templates/error_pages/500.html:14
-msgid "Server"
-msgstr "Servidor"
-
-#: templates/error_pages/500.html:14
-msgid "Error"
-msgstr "Error"
-
-#: templates/error_pages/500.html:15
-msgid ""
-"Click on the button bellow to reload. If the issue persists please contact "
-"support."
+#: templates/mysql/wizard.html:42 templates/psql/wizard.html:42
+msgid "Create a user"
 msgstr ""
-"Haga clic en el botón de abajo para recargar. Si el problema persiste, "
-"póngase en contacto con el servicio de asistencia."
 
-#: templates/error_pages/500.html:16
-msgid "Refresh page"
-msgstr "Actualizar página"
-
-#: templates/partials/sidebar.html:27
-msgid "Select"
-msgstr "Seleccionar"
-
-#: templates/partials/sidebar.html:27
-msgid "website"
-msgstr "sitio web"
-
-#: templates/partials/sidebar.html:39
-msgid "Website"
-msgstr "Sitio web"
-
-#: templates/partials/sidebar.html:44
-msgid "your first domain"
-msgstr "su primer dominio"
-
-#: templates/partials/sidebar.html:47
-msgid "Set up your website"
-msgstr "Configure su sitio web"
-
-#: templates/partials/sidebar.html:173
-msgid "Domain Names"
-msgstr "Dominios"
-
-#: templates/partials/sidebar.html:192
-msgid "Caching & Search"
-msgstr "Caché y búsqueda"
-
-#: templates/partials/sidebar.html:285
-msgid "Analytics"
-msgstr "Analíticas"
-
-#: templates/partials/sidebar.html:298
-msgid "Domain Visitors"
-msgstr "Visitantes del dominio"
-
-#: templates/partials/sidebar.html:325
-msgid "Cron Jobs"
-msgstr "Cron Jobs"
-
-#: templates/partials/sidebar.html:386
-msgid "Log Out"
-msgstr "Desconectarse"
-
-#: templates/partials/sidebar.html:405
-msgid "Documentation"
-msgstr "Documentación"
-
-#: templates/partials/sidebar.html:406
-msgid "Support Forums"
-msgstr "Foros de soporte"
-
-#: templates/partials/sidebar.html:410
-msgid "Toggle dark mode"
-msgstr "Activar modo oscuro"
-
-#: templates/system/general.html:16
-msgid "Server Time"
-msgstr "Hora del servidor"
-
-#: templates/system/general.html:17
-msgid ""
-"Set your server’s time zone and synchronize its time with your network’s "
-"time server."
+#: templates/mysql/wizard.html:45 templates/psql/wizard.html:45
+msgid "Database User"
 msgstr ""
-"Establezca la zona horaria de su servidor y sincronice su hora con la del "
-"servidor horario de su red."
 
-#: templates/system/general.html:34
-msgid "Service Status"
-msgstr "Estado del servicio"
-
-#: templates/system/general.html:35
-msgid ""
-"Display a list of OpenPanel’s monitored services, their current version and "
-"statuses."
+#: templates/mysql/wizard.html:172 templates/psql/wizard.html:172
+msgid "Assign user to database"
 msgstr ""
-"Muestra una lista de los servicios monitorizados de OpenPanel, su versión "
-"actual y sus estados."
 
-#: templates/system/general.html:37
-msgid "Monitor Services"
-msgstr "Monitor de servicios"
+#: templates/mysql/wizard.html:199 templates/psql/wizard.html:199
+msgid "Create DB, User, and Grant Privileges"
+msgstr ""
 
-#: templates/system/general.html:53
-msgid "Configure"
-msgstr "Configurar"
+#: templates/partials/_header.html:54
+msgid "Caching"
+msgstr ""
 
-#: templates/system/general.html:53
-msgid "web server software that handles HTTP requests"
-msgstr "software de servidor web que gestiona las peticiones HTTP"
-
-#: templates/system/general.html:55
-msgid "Configuration"
-msgstr "Configuración"
-
-#: templates/system/general.html:70
-msgid "MySQL Settings"
-msgstr "Ajustes MySQL"
-
-#: templates/system/general.html:71
-msgid "Make changes to your MySQL® or MariaDB® configuration."
-msgstr "Realice cambios en la configuración de MySQL® o MariaDB®."
-
-#: templates/system/general.html:89
-msgid "Make changes to your PHP configuration."
-msgstr "Haga cambios a su configuración de PHP."
-
-#: templates/system/general.html:91
-msgid "PHP Configuration"
-msgstr "Configuración de PHP"
-
-#: templates/system/general.html:106
-msgid "ModSecurity® Settings"
-msgstr "Ajustes de ModSecurity®"
-
-#: templates/system/general.html:107
-msgid "Enable or disable ModSecurity for your domains."
-msgstr "Active o desactive ModSecurity para sus dominios."
-
-#: templates/system/general.html:109
-msgid " ModSecurity Settings"
-msgstr " Ajustes ModSecurity"
-
-#: templates/system/general.html:125
-msgid "Displays information about your account and the server."
-msgstr "Muestra información sobre su cuenta y el servidor."
-
-#: templates/system/modsecurity.html:192
-msgid "Disable ModSecurity"
-msgstr "Desactivar ModSecurity"
-
-#: templates/system/server_info.html:14
-msgid "Hostname"
-msgstr "Nombre de host"
-
-#: templates/system/server_info.html:15
-msgid "Hostname (domain name) that this server is labeled."
-msgstr "Nombre de host (dominio) con el que está etiquetado este servidor."
-
-#: templates/system/server_info.html:23
-msgid "Average Load"
-msgstr "Carga promedio"
-
-#: templates/system/server_info.html:24
-msgid "The system&apos;s average load over the last 1, 5, and 15 minutes"
-msgstr "La carga promedio del sistema en los últimos 1, 5 y 15 minutos"
-
-#: templates/system/server_info.html:32
-msgid "Time the system has been up and running continuously for."
-msgstr "Tiempo que el sistema lleva funcionando de forma ininterrumpida."
-
-#: templates/system/server_info.html:42
-msgid "IP Address"
-msgstr "Dirección IP"
-
-#: templates/system/server_info.html:43
-msgid "The system&apos;s IPv4 address."
-msgstr "La dirección IPv4 del sistema."
-
-#: templates/system/server_info.html:52
-msgid "Panel Version"
-msgstr "Versión del panel"
-
-#: templates/system/server_info.html:53
-msgid "The installed panel software version is"
-msgstr "La versión del software del panel instalado es"
-
-#: templates/system/server_info.html:63
-msgid "OS"
-msgstr "SO"
-
-#: templates/system/server_info.html:64
-msgid "Operating System (OS)"
-msgstr "Sistema Operativo (SO)"
-
-#: templates/system/server_info.html:73
-msgid "Release"
-msgstr "Versión"
-
-#: templates/system/server_info.html:74
-msgid "OS release"
-msgstr "Versión del SO"
-
-#: templates/system/server_info.html:83
-msgid "Current OS version"
-msgstr "Versión actual del SO"
-
-#: templates/system/server_info.html:91
-msgid "Processor"
-msgstr "Procesador"
-
-#: templates/system/server_info.html:92
-msgid "Server Processor Architecture"
-msgstr "Arquitectura del procesador del servidor"
-
-#: templates/system/services_status.html:38
-msgid "Default PHP version is"
-msgstr "La versión predeterminada de PHP es"
-
-#: templates/system/services_status.html:50
-#: templates/system/services_status.html:56
+#: templates/partials/_header.html:69
 msgid "MySQL"
-msgstr "MySQL"
-
-#: templates/system/services_status.html:55
-msgid "Restart MySQL service"
-msgstr "Reiniciar el servicio MySQL"
-
-#: templates/system/services_status.html:68
-msgid ""
-"Even when \"Off\" phpMyAdmin starts automatically when you visit /phpmyadmin"
 msgstr ""
-"Incluso en \"Apagado\" phpMyAdmin se inicia automáticamente cuando usted "
-"visita /phpmyadmin"
 
-#: templates/system/services_status.html:233
-msgid "mysql service restart in progress.."
-msgstr "reinicio del servicio mysql en curso..."
+#: templates/partials/_header.html:74
+msgid "PostgreSQL"
+msgstr ""
 
-#: templates/system/services_status.html:264
-msgid "service restart in progress.."
-msgstr "reinicio de servicio en curso..."
+#: templates/partials/_header.html:79
+msgid "PHP"
+msgstr ""
 
-#: templates/system/timezone.html:21
-msgid "Saving TimeZone..."
-msgstr "Guardando zona horaria..."
+#: templates/partials/_header.html:104
+msgid "Sites"
+msgstr ""
 
-#: templates/system/timezone.html:66
-msgid "Select Timezone:"
-msgstr "Seleccionar zona horaria:"
+#: templates/partials/_header.html:136
+msgid "You are currently impersonating user"
+msgstr ""
 
-#: templates/system/timezone.html:73
+#: templates/partials/_header.html:137
+msgid "Back to"
+msgstr ""
+
+#: templates/partials/_header.html:137
+msgid "OpenAdmin"
+msgstr ""
+
+#: templates/partials/_header.html:162
+msgid "Left-click to add to Favorites"
+msgstr ""
+
+#: templates/partials/_header.html:175
+msgid "This page is not in your favorites! Left-click to add it."
+msgstr ""
+
+#: templates/partials/_header.html:197
+msgid "Successfully removed from favorites!"
+msgstr ""
+
+#: templates/partials/_header.html:208
+msgid "Failed to remove favorite."
+msgstr ""
+
+#: templates/partials/_header.html:215
+msgid "This page is already in your favorites! Right-click to remove it."
+msgstr ""
+
+#: templates/partials/_header.html:247
+msgid "Successfully added to favorites!"
+msgstr ""
+
+#: templates/partials/_header.html:259
+msgid "Failed to add favorite."
+msgstr ""
+
+#: templates/partials/pagespeed.html:19
+msgid "Loading Google PageSpeed data"
+msgstr ""
+
+#: templates/partials/pagespeed.html:20
+msgid "Data refreshes every 24 hours."
+msgstr ""
+
+#: templates/partials/pagespeed.html:53 templates/partials/pagespeed.html:96
+msgid "Desktop"
+msgstr ""
+
+#: templates/partials/pagespeed.html:82 templates/partials/pagespeed.html:97
+msgid "Mobile"
+msgstr ""
+
+#: templates/partials/pagespeed.html:102
+msgid "First Contentful Paint:"
+msgstr ""
+
+#: templates/partials/pagespeed.html:107
+msgid "Speed Index:"
+msgstr ""
+
+#: templates/partials/pagespeed.html:112
+msgid "Time to Interactive:"
+msgstr ""
+
+#: templates/partials/pagespeed.html:117
+msgid "Measured at"
+msgstr ""
+
+#: templates/partials/pagespeed.html:122 templates/partials/pagespeed.html:174
+msgid "PageSpeed Insights API key:"
+msgstr ""
+
+#: templates/partials/pagespeed.html:136 templates/partials/pagespeed.html:188
+msgid "Click to add PageSpeed Insights API key"
+msgstr ""
+
+#: templates/partials/pagespeed.html:138 templates/partials/pagespeed.html:190
+msgid "Ask Administrator to set a PageSpeed Insights API key"
+msgstr ""
+
+#: templates/partials/pagespeed.html:159
+msgid "No data to show"
+msgstr ""
+
+#: templates/partials/pagespeed.html:160
+msgid "May take 24h for data to be shown."
+msgstr ""
+
+#: templates/partials/pagespeed.html:283
+msgid "The site's Google PageSpeed data has been successfully collected."
+msgstr ""
+
+#: templates/partials/pagespeed.html:289
+msgid ""
+"Error fetching Google PageSpeed data for the domain. Please refresh the "
+"page. If the issue continues, contact support for assistance."
+msgstr ""
+
+#: templates/partials/screenshot.html:28
+msgid "Loading screenshot..."
+msgstr ""
+
+#: templates/partials/screenshot.html:44
+msgid "Refresh website screenshot"
+msgstr ""
+
+#: templates/partials/screenshot.html:51
+msgid "Click to refresh sreenshot"
+msgstr ""
+
+#: templates/partials/screenshot.html:66
+msgid "No Screenshot"
+msgstr ""
+
+#: templates/partials/screenshot.html:67
+msgid "Failed to generate website screenshot."
+msgstr ""
+
+#: templates/partials/temp_link.html:2
+msgid "Live Preview"
+msgstr ""
+
+#: templates/partials/temp_link.html:7
+msgid "Preview website on temporary .openpanel.org subdomain"
+msgstr ""
+
+#: templates/partials/temp_link.html:33
+msgid "Link opened in new tab, link is valid for 15 minutes."
+msgstr ""
+
+#: templates/partials/temp_link.html:36
+msgid "No link found in the response. Contact Administrator."
+msgstr ""
+
+#: templates/partials/waf.html:28
+msgid "Firewall"
+msgstr ""
+
+#: templates/partials/waf.html:40
+msgid "Control Coraza WAF for the domain"
+msgstr ""
+
+#: templates/partials/waf.html:56
+msgid "Checking Firewall status.."
+msgstr ""
+
+#: templates/php/default.html:14
+msgid "Default PHP version\n"
+msgstr ""
+
+#: templates/php/default.html:16
+msgid ""
+"Set the default PHP version to be used for new domains.\n"
+"\n"
+msgstr ""
+
+#: templates/php/default.html:21
+msgid "Current default version:"
+msgstr ""
+
+#: templates/php/default.html:36
+msgid "Change PHP Version:"
+msgstr ""
+
+#: templates/php/default.html:40 templates/php/ini_editor.html:90
+#: templates/php/options.html:190
+msgid "Select PHP Version"
+msgstr ""
+
+#: templates/php/default.html:58 templates/php/ini_editor.html:108
+#: templates/php/options.html:208
+msgid "Back to PHP versions"
+msgstr ""
+
+#: templates/php/default.html:62 templates/php/settings.html:260
+#: templates/system/ssh.html:114 templates/system/timezone.html:57
+msgid "Change"
+msgstr ""
+
+#: templates/php/extensions.html:12
+msgid "PHP Extensions"
+msgstr ""
+
+#: templates/php/extensions.html:13
+msgid "View active extensions for running PHP versions."
+msgstr ""
+
+#: templates/php/extensions.html:56
+msgid "Extension"
+msgstr ""
+
+#: templates/php/ini_editor.html:28
+msgid ""
+"Edit PHP.INI file\n"
+" for version"
+msgstr ""
+
+#: templates/php/ini_editor.html:30 templates/php/ini_editor.html:68
+msgid ""
+"Modify PHP settings stored in the php.ini configuration file, such as memory "
+"limits, error reporting, and extension settings."
+msgstr ""
+
+#: templates/php/ini_editor.html:66
+msgid "Edit PHP.INI file\n"
+msgstr ""
+
+#: templates/php/ini_editor.html:86 templates/php/options.html:186
+msgid "Select PHP version:"
+msgstr ""
+
+#: templates/php/limits.html:13
+msgid "PHP Limits"
+msgstr ""
+
+#: templates/php/limits.html:15
+msgid ""
+"Set custom limits for each PHP version. These settings will override those "
+"defined in the PHP Selector and PHP.INI Editor."
+msgstr ""
+
+#: templates/php/options.html:15
+msgid ""
+"Edit options for this PHP version. Any changes will restart the service."
+msgstr ""
+
+#: templates/php/options.html:49
+msgid "Option"
+msgstr ""
+
+#: templates/php/options.html:139
+msgid "Default keys are not available. Contact Administrator."
+msgstr ""
+
+#: templates/php/options.html:165
+msgid "Edit PHP options\n"
+msgstr ""
+
+#: templates/php/options.html:167
+msgid ""
+"Modify PHP options such as memory limits, error reporting, and extension "
+"settings."
+msgstr ""
+
+#: templates/php/options.html:212
+msgid "Edit Options"
+msgstr ""
+
+#: templates/php/settings.html:12
+msgid "PHP version for domains"
+msgstr ""
+
+#: templates/php/settings.html:13
+msgid ""
+"Changing the PHP version will stop all the processes on your site. It takes "
+"1-2 seconds to complete."
+msgstr ""
+
+#: templates/php/settings.html:14
+msgid ""
+"Be sure to check your script and plugin requirements to know which PHP "
+"version works best for your website."
+msgstr ""
+
+#: templates/php/settings.html:156
+msgid "Current PHP Version"
+msgstr ""
+
+#: templates/php/settings.html:157
+msgid "Change version"
+msgstr ""
+
+#: templates/psql/assign.html:11
+msgid ""
+"Assign a user to an existing PostgreSQL database to manage database "
+"permissions and enable access for executing queries, modifying tables, or "
+"managing data within the specified database."
+msgstr ""
+
+#: templates/psql/assign.html:44
+msgid "Select a database"
+msgstr ""
+
+#: templates/psql/configuration.html:14
+msgid ""
+"View and modify the PostgreSQL service configuration. Any changes will "
+"restart the service."
+msgstr ""
+
+#: templates/psql/databases.html:10
+msgid "PostgreSQL Databases"
+msgstr ""
+
+#: templates/psql/databases.html:161
+msgid "System Database"
+msgstr ""
+
+#: templates/psql/databases.html:182
+msgid "No databases"
+msgstr ""
+
+#: templates/psql/import.html:8
+msgid "Selet a local file to upload and import into a PostgreSQL database."
+msgstr ""
+
+#: templates/psql/mysql_user.html:11 templates/psql/psql_user.html:7
+msgid "Create PostgreSQL User"
+msgstr ""
+
+#: templates/psql/mysql_user.html:12
+msgid ""
+"Create a new PostgreSQL user with a unique username and password to securely "
+"manage access and permissions for interacting with databases or the "
+"PostgreSQL server."
+msgstr ""
+
+#: templates/psql/mysql_user.html:42
+msgid "Random Password"
+msgstr ""
+
+#: templates/psql/new.html:8
+msgid ""
+"Create a new PostgreSQL database to store and organize data, providing a "
+"foundational structure for applications to manage and retrieve information "
+"efficiently."
+msgstr ""
+
+#: templates/psql/password.html:11
+msgid "Change password for a PostgreSQL database user."
+msgstr ""
+
+#: templates/psql/pgadmin.html:15 templates/psql/pgadmin.html:50
+msgid "Enable/disable pgAdmin service."
+msgstr ""
+
+#: templates/psql/pgadmin.html:25
+msgid "Open pgAdmin Login"
+msgstr ""
+
+#: templates/psql/pgadmin.html:114
+msgid "Login information for the pgAdmin container."
+msgstr ""
+
+#: templates/psql/pgadmin.html:121
+msgid "Email:"
+msgstr ""
+
+#: templates/psql/pgadmin.html:160
+msgid "IP and Port for accessing the pgAdmin service."
+msgstr ""
+
+#: templates/psql/pgadmin.html:186
+msgid "View pgAdmin service logs."
+msgstr ""
+
+#: templates/psql/processlist.html:7
+msgid "PostgreSQL Processes"
+msgstr ""
+
+#: templates/psql/processlist.html:9
+msgid ""
+"List of all current processes running on the PostgreSQL server, providing "
+"insights into ongoing queries, operations, and their associated details for "
+"better performance monitoring."
+msgstr ""
+
+#: templates/psql/processlist.html:84
+msgid "datid"
+msgstr ""
+
+#: templates/psql/processlist.html:94
+msgid "datname"
+msgstr ""
+
+#: templates/psql/processlist.html:104
+msgid "pid"
+msgstr ""
+
+#: templates/psql/processlist.html:114
+msgid "leader_pid"
+msgstr ""
+
+#: templates/psql/processlist.html:124
+msgid "usesysid"
+msgstr ""
+
+#: templates/psql/processlist.html:134
+msgid "usename"
+msgstr ""
+
+#: templates/psql/processlist.html:144
+msgid "application_name"
+msgstr ""
+
+#: templates/psql/processlist.html:154
+msgid "client_addr"
+msgstr ""
+
+#: templates/psql/processlist.html:164
+msgid "client_hostname"
+msgstr ""
+
+#: templates/psql/processlist.html:174
+msgid "client_port"
+msgstr ""
+
+#: templates/psql/processlist.html:184
+msgid "backend_start"
+msgstr ""
+
+#: templates/psql/processlist.html:194
+msgid "xact_start"
+msgstr ""
+
+#: templates/psql/processlist.html:204
+msgid "query_start"
+msgstr ""
+
+#: templates/psql/processlist.html:214
+msgid "state_change"
+msgstr ""
+
+#: templates/psql/processlist.html:224
+msgid "wait_event_type"
+msgstr ""
+
+#: templates/psql/processlist.html:234
+msgid "wait_event"
+msgstr ""
+
+#: templates/psql/processlist.html:244
+msgid "state"
+msgstr ""
+
+#: templates/psql/processlist.html:254
+msgid "backend_xid"
+msgstr ""
+
+#: templates/psql/processlist.html:264
+msgid "backend_xmin"
+msgstr ""
+
+#: templates/psql/processlist.html:274
+msgid "query_id"
+msgstr ""
+
+#: templates/psql/processlist.html:284
+msgid "query"
+msgstr ""
+
+#: templates/psql/processlist.html:294
+msgid "backend_type"
+msgstr ""
+
+#: templates/psql/processlist.html:310
+msgid "Datid"
+msgstr ""
+
+#: templates/psql/processlist.html:311
+msgid "Datname"
+msgstr ""
+
+#: templates/psql/processlist.html:312
+msgid "Pid"
+msgstr ""
+
+#: templates/psql/processlist.html:313
+msgid "Leader_pid"
+msgstr ""
+
+#: templates/psql/processlist.html:314
+msgid "Usesysid"
+msgstr ""
+
+#: templates/psql/processlist.html:315
+msgid "Usename"
+msgstr ""
+
+#: templates/psql/processlist.html:316
+msgid "Application_name"
+msgstr ""
+
+#: templates/psql/processlist.html:317
+msgid "Client_addr"
+msgstr ""
+
+#: templates/psql/processlist.html:318
+msgid "Client_hostname"
+msgstr ""
+
+#: templates/psql/processlist.html:319
+msgid "Client_port"
+msgstr ""
+
+#: templates/psql/processlist.html:320
+msgid "Backend_start"
+msgstr ""
+
+#: templates/psql/processlist.html:321
+msgid "Xact_start"
+msgstr ""
+
+#: templates/psql/processlist.html:322
+msgid "Query_start"
+msgstr ""
+
+#: templates/psql/processlist.html:323
+msgid "State_change"
+msgstr ""
+
+#: templates/psql/processlist.html:324
+msgid "Wait_event_type"
+msgstr ""
+
+#: templates/psql/processlist.html:325
+msgid "Wait_event"
+msgstr ""
+
+#: templates/psql/processlist.html:327
+msgid "Backend_xid"
+msgstr ""
+
+#: templates/psql/processlist.html:328
+msgid "Backend_xmin"
+msgstr ""
+
+#: templates/psql/processlist.html:329
+msgid "Query_id"
+msgstr ""
+
+#: templates/psql/processlist.html:330
+msgid "Query"
+msgstr ""
+
+#: templates/psql/processlist.html:331
+msgid "Backend_type"
+msgstr ""
+
+#: templates/psql/psql_user.html:8
+msgid ""
+"Create a new Postgres user with a unique username and password to securely "
+"manage access and permissions for interacting with databases or the "
+"PostgreSQL server."
+msgstr ""
+
+#: templates/psql/remote_psql.html:14
+msgid "Remote PostgreSQL Access"
+msgstr ""
+
+#: templates/psql/remote_psql.html:15
+msgid ""
+"Connect to a PostgreSQL database on this server from a another (remote) "
+"device or location over the internet."
+msgstr ""
+
+#: templates/psql/remote_psql.html:24 templates/psql/remote_psql.html:38
+msgid "Disable Remote PostgreSQL Access"
+msgstr ""
+
+#: templates/psql/remote_psql.html:31 templates/psql/remote_psql.html:44
+msgid "Enable Remote PostgreSQL Access"
+msgstr ""
+
+#: templates/psql/remote_psql.html:61
+msgid "Remote access to PostgreSQL is currently:"
+msgstr ""
+
+#: templates/psql/remove.html:11
+msgid ""
+"Remove a user from an existing PostgreSQL database to revoke their "
+"permissions and prevent access to executing queries, modifying tables, or "
+"managing data within the specified database."
+msgstr ""
+
+#: templates/psql/users.html:9
+msgid "PostgreSQL Users"
+msgstr ""
+
+#: templates/psql/wizard.html:9
+msgid ""
+"Create a new PostgreSQL database, set up a user with a secure password, and "
+"assign it to the database with all necessary privileges."
+msgstr ""
+
+#: templates/system/apache_nginx_conf_editor.html:23
+msgid "Edit main webserver configuration file:"
+msgstr ""
+
+#: templates/system/cronjobs.html:24
+msgid ""
+"A cron job is a Linux command used to schedule tasks for future execution."
+msgstr ""
+
+#: templates/system/cronjobs.html:25
+msgid ""
+"It allows you to automate repetitive tasks, such as sending notifications or "
+"running scripts at specific intervals."
+msgstr ""
+
+#: templates/system/cronjobs.html:28
+msgid "Crontab File Editor"
+msgstr ""
+
+#: templates/system/cronjobs.html:29
+msgid ""
+"Editing crontab file is intended for advanced users only. If you mistyped "
+"the cron entry in the file, you will not be warned as opposed to when saving "
+"cronjobs in table mode."
+msgstr ""
+
+#: templates/system/cronjobs.html:116
+msgid "Create New"
+msgstr ""
+
+#: templates/system/cronjobs.html:118 templates/system/cronjobs_new.html:19
+msgid "Switch to File Editor"
+msgstr ""
+
+#: templates/system/cronjobs.html:131
+msgid "Schedule"
+msgstr ""
+
+#: templates/system/cronjobs.html:140
+msgid "Name/Comment"
+msgstr ""
+
+#: templates/system/cronjobs.html:180 templates/system/cronjobs_new.html:88
+msgid "optional"
+msgstr ""
+
+#: templates/system/cronjobs.html:281
+msgid "No cronjobs."
+msgstr ""
+
+#: templates/system/cronjobs.html:283
+msgid "No cronjobs yet, to create a cron click on the button above."
+msgstr ""
+
+#: templates/system/cronjobs_new.html:10
+msgid "Create Cron Job"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:13
+msgid ""
+"Select a container in which the script will be executed and set schedule. To "
+"add multiple jobs at once, use the File Editor instead."
+msgstr ""
+
+#: templates/system/cronjobs_new.html:35
+msgid "Select Container:"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:38
+msgid "-- Select --"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:48
+msgid "Schedule:"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:59
+msgid "Common schedules:"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:62
+msgid "-- Common Settings --"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:63
+msgid "Every 30 Seconds"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:64
+msgid "Every Minute"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:65
+msgid "Every 5 Minutes"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:66
+msgid "Every 30 Minutes"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:67
+msgid "Hourly"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:68
+msgid "Daily"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:69
+msgid "Weekly"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:70
+msgid "Monthly"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:71
+msgid "Yearly"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:77
+msgid "Command:"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:85
+msgid "Comment:"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:96
+msgid "Back to CronJobs"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:100
+msgid "Schedule CronJob"
+msgstr ""
+
+#: templates/system/cronjobs_new.html:124
+msgid "Please fill in all required fields before submitting."
+msgstr ""
+
+#: templates/system/process_manager.html:10
+msgid "View and manage currently running processes on the server."
+msgstr ""
+
+#: templates/system/process_manager.html:72
+msgid "PID"
+msgstr ""
+
+#: templates/system/process_manager.html:79
+msgid "PPID"
+msgstr ""
+
+#: templates/system/process_manager.html:86 templates/user/stats.html:51
+msgid "CPU"
+msgstr ""
+
+#: templates/system/process_manager.html:93
+msgid "STIME"
+msgstr ""
+
+#: templates/system/process_manager.html:100
+msgid "TTY"
+msgstr ""
+
+#: templates/system/process_manager.html:107
+msgid "TIME"
+msgstr ""
+
+#: templates/system/process_manager.html:116
+msgid "CMD"
+msgstr ""
+
+#: templates/system/process_manager.html:119
+msgid "ACTION"
+msgstr ""
+
+#: templates/system/process_manager.html:141
+msgid "View full command"
+msgstr ""
+
+#: templates/system/process_manager.html:151
+msgid "kill"
+msgstr ""
+
+#: templates/system/server_info.html:11
+msgid "View current server specification and system usage."
+msgstr ""
+
+#: templates/system/server_info.html:31
+msgid "Hostname"
+msgstr ""
+
+#: templates/system/server_info.html:34 templates/system/server_info.html:43
+#: templates/system/server_info.html:54 templates/system/server_info.html:63
+#: templates/system/server_info.html:115 templates/system/server_info.html:125
+#: templates/system/server_info.html:137 templates/system/server_info.html:149
+#: templates/system/server_info.html:162 templates/system/server_info.html:202
+#: templates/system/server_info.html:212 templates/system/server_info.html:221
+#: templates/system/server_info.html:230 templates/system/server_info.html:239
+#: templates/system/server_info.html:249 templates/system/server_info.html:259
+#: templates/system/server_info.html:268 templates/system/server_info.html:279
+#: templates/system/server_info.html:288 templates/system/server_info.html:297
+#: templates/system/server_info.html:306 templates/system/server_info.html:315
+msgid "Loading..."
+msgstr ""
+
+#: templates/system/server_info.html:40
+msgid "Average Load"
+msgstr ""
+
+#: templates/system/server_info.html:51
+msgid "Uptime"
+msgstr ""
+
+#: templates/system/server_info.html:70
+msgid "Ports"
+msgstr ""
+
+#: templates/system/server_info.html:78
+msgid "Remote MySQL port"
+msgstr ""
+
+#: templates/system/server_info.html:84
+msgid "Local MySQL port"
+msgstr ""
+
+#: templates/system/server_info.html:90
+msgid "phpMyAdmin port"
+msgstr ""
+
+#: templates/system/server_info.html:96
+msgid "Remote SSH port"
+msgstr ""
+
+#: templates/system/server_info.html:102
+msgid "Remote PostgreSQL port"
+msgstr ""
+
+#: templates/system/server_info.html:112
+msgid "OS"
+msgstr ""
+
+#: templates/system/server_info.html:122
+msgid "Release"
+msgstr ""
+
+#: templates/system/server_info.html:146
+msgid "Processor"
+msgstr ""
+
+#: templates/system/server_info.html:181
+msgid "Hosting Plan"
+msgstr ""
+
+#: templates/system/server_info.html:189
+msgid "Plan Name"
+msgstr ""
+
+#: templates/system/server_info.html:199
+msgid "Description"
+msgstr ""
+
+#: templates/system/server_info.html:209
+msgid "Context"
+msgstr ""
+
+#: templates/system/server_info.html:218
+msgid "Bandwidth Limit"
+msgstr ""
+
+#: templates/system/server_info.html:227
+msgid "CPU Limit"
+msgstr ""
+
+#: templates/system/server_info.html:236
+msgid "Database Limit"
+msgstr ""
+
+#: templates/system/server_info.html:246
+msgid "Websites Limit"
+msgstr ""
+
+#: templates/system/server_info.html:256
+msgid "Disk Limit"
+msgstr ""
+
+#: templates/system/server_info.html:265
+msgid "Domains Limit"
+msgstr ""
+
+#: templates/system/server_info.html:276
+msgid "Email Limit"
+msgstr ""
+
+#: templates/system/server_info.html:285
+msgid "FTP Limit"
+msgstr ""
+
+#: templates/system/server_info.html:294
+msgid "Inodes Limit"
+msgstr ""
+
+#: templates/system/server_info.html:303
+msgid "MySQL Server"
+msgstr ""
+
+#: templates/system/server_info.html:312
+msgid "Web Server"
+msgstr ""
+
+#: templates/system/server_info.html:328
+msgid "OpenPanel Information"
+msgstr ""
+
+#: templates/system/server_info.html:334
+msgid "OpenPanel Version"
+msgstr ""
+
+#: templates/system/server_info.html:347
+msgid "Enabled Modules"
+msgstr ""
+
+#: templates/system/ssh.html:14
+msgid "SSH login information for managing containers via"
+msgstr ""
+
+#: templates/system/ssh.html:27
+msgid "Current ssh service status."
+msgstr ""
+
+#: templates/system/ssh.html:63
+msgid "Server IP and SSH service port."
+msgstr ""
+
+#: templates/system/ssh.html:85
+msgid "Credentials"
+msgstr ""
+
+#: templates/system/ssh.html:86
+msgid "SSH username and password."
+msgstr ""
+
+#: templates/system/ssh.html:92
+msgid "Username:"
+msgstr ""
+
+#: templates/system/ssh.html:103
+msgid "Click to change"
+msgstr ""
+
+#: templates/system/timezone.html:11
 msgid "Change Timezone"
-msgstr "Cambiar zona horaria"
-
-#: templates/user/account.html:8 templates/user/activity.html:113
-#: templates/user/loginlog.html:8 templates/user/twofa_settings.html:7
-msgid "Profile"
-msgstr "Perfil"
-
-#: templates/user/account.html:10 templates/user/twofa_settings.html:9
-msgid "2FA"
-msgstr "2FA"
-
-#: templates/user/account.html:15 templates/user/activity.html:117
-#: templates/user/loginlog.html:12 templates/user/twofa_settings.html:11
-msgid "History"
-msgstr "Historial"
-
-#: templates/user/account.html:24
-msgid "Profile Picture"
-msgstr "Foto de perfil"
-
-#: templates/user/account.html:28
-msgid "This image is from Gravatar"
-msgstr "Esta imagen es de Gravatar"
-
-#: templates/user/account.html:31
-msgid "Change image on Gravatar"
-msgstr "Cambiar imagen en Gravatar"
-
-#: templates/user/account.html:44
-msgid "Account Details"
-msgstr "Detalles de la cuenta"
-
-#: templates/user/account.html:49
-msgid "Email address:"
-msgstr "Dirección de email:"
-
-#: templates/user/account.html:71
-msgid "Confirm New Password:"
-msgstr "Confirmar nueva contraseña:"
-
-#: templates/user/account.html:73
-msgid "Confirm New Password"
-msgstr "Confirmar nueva contraseña"
-
-#: templates/user/account.html:77 templates/user/account.html:215
-msgid "Copy Password"
-msgstr "Copiar contraseña"
-
-#: templates/user/account.html:84
-msgid "Update"
-msgstr "Actualizar"
-
-#: templates/user/account.html:92
-msgid "Theme"
-msgstr "Tema"
-
-#: templates/user/account.html:212
-msgid "Copied to clipboard"
-msgstr "Copiado al portapapeles"
-
-#: templates/user/activity.html:121
-msgid ""
-"Activity Log records all important actions performed by user on the panel, "
-"such as editing or modifying files, deleting websites, enabling SSH access, "
-"etc."
 msgstr ""
-"El Registro de actividad registra todas las acciones importantes realizadas "
-"por el usuario en el panel, como editar o modificar archivos, eliminar "
-"sitios web, habilitar el acceso SSH, etc."
 
-#: templates/user/activity.html:147
-msgid "Show all activity"
-msgstr "Mostrar toda la actividad"
+#: templates/system/timezone.html:12
+msgid "Change system timezone."
+msgstr ""
 
-#: templates/user/activity.html:215
-msgid "Last"
-msgstr "Último"
+#: templates/system/timezone.html:16
+msgid "Current timezone:"
+msgstr ""
 
-#: templates/user/history_usage.html:15
-msgid "Historical CPU and Memory Usage:"
-msgstr "Uso histórico de CPU y memoria:"
+#: templates/system/timezone.html:33
+msgid "Change system timezone:"
+msgstr ""
 
-#: templates/user/history_usage.html:26
-msgid "Historical CPU Usage:"
-msgstr "Uso histórico de la CPU:"
+#: templates/system/timezone.html:46
+msgid "Can't find your timezone?"
+msgstr ""
 
-#: templates/user/history_usage.html:34
-msgid "Historical Memory Usage:"
-msgstr "Uso histórico de memoria:"
+#: templates/system/timezone.html:46
+msgid "List of tz database time zones"
+msgstr ""
 
-#: templates/user/history_usage.html:58
+#: templates/system/waf.html:9
+msgid ""
+"Enable or disable OWASP Coraza Web Application Firewall protection for "
+"domains."
+msgstr ""
+
+#: templates/system/waf.html:104
+msgid "Manage Rules"
+msgstr ""
+
+#: templates/system/waf.html:105
+msgid "View Logs"
+msgstr ""
+
+#: templates/system/waf_domain.html:11
+msgid "Manage WAF settings for a domain."
+msgstr ""
+
+#: templates/system/waf_domain.html:30
+msgid "Enable/disable WAF for"
+msgstr ""
+
+#: templates/system/waf_logs.html:11
+msgid "WAF Logs for"
+msgstr ""
+
+#: templates/system/waf_logs.html:260
+msgid "View Coraza WAF logs for domains."
+msgstr ""
+
+#: templates/user/account.html:14
+msgid ""
+"Update email address to receive notifications or change the password for "
+"logging into your account, ensuring secure and up-to-date access."
+msgstr ""
+
+#: templates/user/account.html:72
+msgid ""
+"Username must be between 3 and 20 characters, and only contain letters and "
+"numbers (no spaces, hyphens, or underscores)."
+msgstr ""
+
+#: templates/user/active_sessions.html:13
+msgid "View all currently active sessions for your account."
+msgstr ""
+
+#: templates/user/active_sessions.html:56
+msgid "Created On"
+msgstr ""
+
+#: templates/user/active_sessions.html:75 templates/user/loginlog.html:77
+msgid "View activity log for IP "
+msgstr ""
+
+#: templates/user/active_sessions.html:75
+msgid "View activity logs"
+msgstr ""
+
+#: templates/user/active_sessions.html:87
+msgid "Terminate"
+msgstr ""
+
+#: templates/user/activity.html:13
+msgid "Activity Log"
+msgstr ""
+
+#: templates/user/activity.html:15
+msgid "View recent user activity and system events."
+msgstr ""
+
+#: templates/user/email_template.html:50
+msgid "Click the button below to reset your password:"
+msgstr ""
+
+#: templates/user/email_template.html:66
+msgid "Or copy and paste this link in your browser:"
+msgstr ""
+
+#: templates/user/email_template.html:101
+msgid "Password Reset requested from OpenPanel server:"
+msgstr ""
+
+#: templates/user/email_template.html:103
+msgid "Notification sent from OpenPanel server:"
+msgstr ""
+
+#: templates/user/email_template.html:142
+msgid "Click here to login to your account"
+msgstr ""
+
+#: templates/user/email_template.html:144
+msgid "Click here to manage notification preferences for your account"
+msgstr ""
+
+#: templates/user/favorites.html:14
+msgid ""
+"Add a page to favorites by left-clicking the star in the top-right corner of "
+"any page and remove it either from this page or by right-clicking the same "
+"star."
+msgstr ""
+
+#: templates/user/favorites.html:53
+msgid "Title"
+msgstr ""
+
+#: templates/user/favorites.html:113
+msgid "Favorites are not enabled by the Administrator."
+msgstr ""
+
+#: templates/user/favorites.html:114
+msgid ""
+"The Favorites feature is currently disabled by the administrator; please "
+"contact your administrator to enable it."
+msgstr ""
+
+#: templates/user/history_usage.html:20 templates/user/history_usage.html:56
+msgid "Historical CPU and Memory Usage"
+msgstr ""
+
+#: templates/user/history_usage.html:22
+msgid "View past CPU and Memory usage."
+msgstr ""
+
+#: templates/user/history_usage.html:76
+msgid "History CPU Usage"
+msgstr ""
+
+#: templates/user/history_usage.html:89
+msgid "History Memory Usage"
+msgstr ""
+
+#: templates/user/history_usage.html:127
 msgid "Show all data"
-msgstr "Mostrar toda la info"
+msgstr ""
 
-#: templates/user/history_usage.html:70
+#: templates/user/history_usage.html:151
 msgid "CPU &#37;"
-msgstr "CPU &#37;"
+msgstr ""
 
-#: templates/user/history_usage.html:71
+#: templates/user/history_usage.html:153
 msgid "Memory &#37;"
-msgstr "Memoria &#37;"
+msgstr ""
 
-#: templates/user/history_usage.html:72
+#: templates/user/history_usage.html:154
 msgid "Net I/O"
-msgstr "I/O de red"
+msgstr ""
 
-#: templates/user/history_usage.html:73 templates/user/stats.html:158
-msgid "Block I/O"
-msgstr "I/O de bloque"
+#: templates/user/history_usage.html:180
+msgid "First"
+msgstr ""
 
-#: templates/user/login.html:11
-msgid "UNLIMITED.RS"
-msgstr "UNLIMITED.RS"
+#: templates/user/history_usage.html:217
+msgid "Last"
+msgstr ""
 
-#: templates/user/login.html:28 templates/user/login.html:62
-msgid "Sign In"
-msgstr "Iniciar sesión"
+#: templates/user/locale.html:13
+msgid "Change locale for your account."
+msgstr ""
 
-#: templates/user/login.html:29
-msgid "Welcome back! Please sign in to continue."
-msgstr "¡Bienvenido/a de nuevo! Inicie sesión para continuar."
+#: templates/user/locale.html:35
+msgid "Choose Language"
+msgstr ""
+
+#: templates/user/locale.html:36
+msgid "Current"
+msgstr ""
+
+#: templates/user/login.html:8
+msgid "Sign in to your account"
+msgstr ""
+
+#: templates/user/login.html:20
+msgid "Enter your panel username"
+msgstr ""
+
+#: templates/user/login.html:23
+msgid "Forgot password?"
+msgstr ""
+
+#: templates/user/login.html:32
+msgid "Two-Factor Authentication Code"
+msgstr ""
 
 #: templates/user/login.html:37
-msgid "Enter your panel username"
-msgstr "Introduzca su usuario del panel"
-
-#: templates/user/login.html:41
-msgid "Forgot password?"
-msgstr "Olvidó su contraseña?"
-
-#: templates/user/login.html:42
-msgid "Enter your password"
-msgstr "Ingrese su contraseña"
-
-#: templates/user/login.html:50
-msgid "Two-Factor Authentication Code"
-msgstr "Código de autenticación de dos factores"
-
-#: templates/user/login.html:51
-msgid "Enter your 2FA code"
-msgstr "Ingrese su código 2FA"
-
-#: templates/user/loginlog.html:32
-msgid "Click to copy IP"
-msgstr "Clic para copiar la IP"
-
-#: templates/user/loginlog.html:33
-msgid "Copied!"
-msgstr "Copiada!"
-
-#: templates/user/stats.html:11
-msgid "Current CPU usage:"
-msgstr "Uso de CPU actual:"
-
-#: templates/user/stats.html:13 templates/user/stats.html:29
-msgid "View top processes"
-msgstr "Ver procesos con mayor consumo"
-
-#: templates/user/stats.html:13 templates/user/stats.html:29
-msgid "View past usage"
-msgstr "Ver historial de uso"
-
-#: templates/user/stats.html:24
-msgid "RAM"
-msgstr "RAM"
-
-#: templates/user/stats.html:27
-msgid "Current Memory usage:"
-msgstr "Uso de memoria actual:"
-
-#: templates/user/stats.html:152
-msgid "Network I/O"
-msgstr "I/O de red"
-
-#: templates/user/stats.html:164
-msgid "PIDs"
-msgstr "PIDs"
-
-#: templates/user/twofa_settings.html:28
-msgid "wo-factor authentication"
-msgstr "autenticación de dos factores"
-
-#: templates/user/twofa_settings.html:28
-msgid "also known as"
-msgstr "también conocida como"
-
-#: templates/user/twofa_settings.html:28
-msgid "2-step verification"
-msgstr "autenticación de 2 pasos"
-
-#: templates/user/twofa_settings.html:28
-msgid "2-phase authentication"
-msgstr "autenticación de 2 fases"
-
-#: templates/user/twofa_settings.html:28
-msgid ""
-"is a way of adding additional security to your account. 2FA requires you to "
-"enter an extra code when you log in or perform some account-sensitive "
-"action. The code is generated from an application on your computer or mobile "
-"phone."
+msgid "Sign In"
 msgstr ""
-"es una forma de agregar seguridad adicional a su cuenta. La 2FA requiere que "
-"introduzca un código adicional al iniciar sesión o realizar alguna acción "
-"sensible para la cuenta. El código se genera desde una aplicación en su "
-"ordenador o teléfono móvil."
 
-#: templates/user/twofa_settings.html:30
+#: templates/user/loginlog.html:12
+msgid "Overview of successful logins on your account."
+msgstr ""
+
+#: templates/user/loginlog.html:49
+msgid "Country and IP address"
+msgstr ""
+
+#: templates/user/loginlog.html:50
+msgid "Login Time"
+msgstr ""
+
+#: templates/user/loginlog.html:66
+msgid "Click to copy IP"
+msgstr ""
+
+#: templates/user/notifications.html:12
+msgid "Select events for which to receive email notifications."
+msgstr ""
+
+#: templates/user/notifications.html:29
+msgid "Receive email notifications for"
+msgstr ""
+
+#: templates/user/notifications.html:48
+msgid "Save Preferences"
+msgstr ""
+
+#: templates/user/stats.html:22
+msgid "View current resource usage for all websites and services."
+msgstr ""
+
+#: templates/user/stats.html:32
+msgid "View Usage History"
+msgstr ""
+
+#: templates/user/stats.html:56
+msgid "Current CPU usage:"
+msgstr ""
+
+#: templates/user/stats.html:65
+msgid "RAM"
+msgstr ""
+
+#: templates/user/stats.html:70
+msgid "Current Memory usage:"
+msgstr ""
+
+#: templates/user/stats.html:139
+msgid "Displaying real-time information"
+msgstr ""
+
+#: templates/user/stats.html:141
+msgid "Last refreshed at"
+msgstr ""
+
+#: templates/user/twofa_settings.html:13
+msgid "2FA is currently"
+msgstr ""
+
+#: templates/user/twofa_settings.html:15
+msgid "enabled"
+msgstr ""
+
+#: templates/user/twofa_settings.html:17
+msgid "disabled"
+msgstr ""
+
+#: templates/user/twofa_settings.html:19
+msgid "for your account."
+msgstr ""
+
+#: templates/user/twofa_settings.html:32
+msgid "Click to Cancel"
+msgstr ""
+
+#: templates/user/twofa_settings.html:40
+msgid "Click to enable 2FA"
+msgstr ""
+
+#: templates/user/twofa_settings.html:64
+msgid "Step 1. Scan QR Code"
+msgstr ""
+
+#: templates/user/twofa_settings.html:67
+msgid "Step 2. Remove OTP code"
+msgstr ""
+
+#: templates/user/twofa_settings.html:79
+msgid ""
+"Scan the QR code with your 2FA device or click on the button bellow to "
+"display OTP code instead."
+msgstr ""
+
+#: templates/user/twofa_settings.html:94
+msgid "Click here to display OTP code"
+msgstr ""
+
+#: templates/user/twofa_settings.html:134
+msgid ""
+"I confirm that the OTP code is configured in my application and confirm to "
+"permanently delete the OTP secret."
+msgstr ""
+
+#: templates/user/twofa_settings.html:157
 msgid ""
 "To enable 2FA for your account you will need an application that manages 2FA "
 "codes, such as"
 msgstr ""
-"Para activar 2FA para su cuenta necesitará una aplicación que gestione "
-"códigos 2FA, como por ejemplo"
 
-#: templates/user/twofa_settings.html:30
+#: templates/user/twofa_settings.html:157
 msgid "Google Authenticator"
-msgstr "Google Authenticator"
-
-#: templates/user/twofa_settings.html:30
-msgid "You can install it here:"
-msgstr "Puede instalarla aquí:"
-
-#: templates/user/twofa_settings.html:36 templates/user/twofa_settings.html:43
-msgid "2FA is currently"
-msgstr "2FA está actualmente"
-
-#: templates/user/twofa_settings.html:36
-msgid "enabled"
-msgstr "activada"
-
-#: templates/user/twofa_settings.html:36 templates/user/twofa_settings.html:43
-msgid "for your account."
-msgstr "para su cuenta."
-
-#: templates/user/twofa_settings.html:43
-msgid "disabled"
-msgstr "desactivada"
-
-#: templates/user/twofa_settings.html:60
-msgid "QR code"
-msgstr "Código QR"
-
-#: templates/user/twofa_settings.html:80
-msgid "Display OTP code"
-msgstr "Mostrar código OTP"
-
-#: templates/user/twofa_settings.html:109
-msgid ""
-"After configuring the OTP code in the 2FA application, kindly confirm by "
-"clicking the button below to permanently delete the OTP secret."
 msgstr ""
-"Después de configurar el código OTP en la aplicación 2FA, por favor confirme "
-"haciendo clic en el botón de abajo para eliminar permanentemente el secreto "
-"OTP."
+
+#: templates/user/reset_password/link_is_sent.html:15
+msgid ""
+"Please check your email and click the link within the next 15 minutes to "
+"reset your password."
+msgstr ""
+
+#: templates/user/reset_password/link_is_sent.html:16
+#: templates/user/reset_password/request_email.html:20
+msgid "Back to Login"
+msgstr ""
+
+#: templates/user/reset_password/request_email.html:8
+msgid "Forgot Your Password?"
+msgstr ""
+
+#: templates/user/reset_password/request_email.html:11
+msgid ""
+"Enter your email address and we'll send you a link to reset your password."
+msgstr ""
+
+#: templates/user/reset_password/request_email.html:21
+msgid "Enter your email address"
+msgstr ""
+
+#: templates/user/reset_password/request_email.html:24
+msgid "Send Reset Link"
+msgstr ""
+
+#: templates/user/reset_password/set_new_password.html:8
+msgid "Reset Your Password"
+msgstr ""
+
+#: templates/user/reset_password/set_new_password.html:48
+msgid "Passwords do not match."
+msgstr ""


### PR DESCRIPTION
This update originates from Ticket ID: USB-933692, where the request was to duplicate the en-US translations into es-ES and translate all strings accordingly.