### PR TITLE
fix: assign static IPs to openpanel_network to prevent stale iptables DNAT rules on port 2083

### DIFF
--- a/configuration/docker/compose/docker-compose.yml
+++ b/configuration/docker/compose/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       - /etc/localtime:/etc/localtime:ro
     oom_kill_disable: true
     networks:
-      - openpanel_network
+      openpanel_network:
+        ipv4_address: 172.20.0.3
     deploy:
       resources:
         limits:
@@ -52,7 +53,8 @@ services:
       - ${REDIS_SOCKET}:/tmp/redis
     restart: always
     networks:
-      - openpanel_network
+      openpanel_network:
+        ipv4_address: 172.20.0.4
     deploy:
       resources:
         limits:
@@ -93,7 +95,8 @@ services:
       - /var/lib/csf/:/var/lib/csf/       #TODO: remove ratelimiting and this
     restart: always
     networks:
-      - openpanel_network
+      openpanel_network:
+        ipv4_address: 172.20.0.5
     deploy:
       resources:
         limits:
@@ -136,7 +139,8 @@ services:
     restart: unless-stopped
     oom_kill_disable: true
     networks:
-      - openpanel_network
+      openpanel_network:
+        ipv4_address: 172.20.0.2
     deploy:
       resources:
         limits:
@@ -163,7 +167,8 @@ services:
       - /etc/openpanel/caddy/ssl/:/etc/openpanel/caddy/ssl/:ro #ssl
       - /etc/localtime:/etc/localtime:ro
     networks:
-      - openpanel_network
+      openpanel_network:
+        ipv4_address: 172.20.0.6
     deploy:
       resources:
         limits:
@@ -183,4 +188,6 @@ networks:
     labels:
       description: "This network allows OpenPanel UI to communicate to system containers."
       purpose: "internal"
-  
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24


### PR DESCRIPTION
## Problem

When Docker restarts or only the `openpanel` container is recreated, Docker re-assigns IPs dynamically from the bridge network pool. If the daemon crashes or a CSF/lfd firewall restores iptables rules on boot, **stale DNAT rules survive** pointing port `2083` to a previously-used IP — which may now belong to a different container (e.g. `openpanel_mysql`).

**Symptom:** The user panel at `:2083` returns "Connection refused" while the admin panel at `:2087` works fine. The `openpanel` service is running correctly but all traffic on port 2083 is forwarded by iptables to MySQL.

**Root cause (confirmed on a live system):**
```
# iptables -t nat -L DOCKER -n
DNAT  tcp  0.0.0.0/0  →  172.18.0.4:2083  (← MySQL, stale rule)
DNAT  tcp  0.0.0.0/0  →  172.18.0.3:2083  (← openpanel, correct but never reached)
```
iptables uses the **first matching rule**, so all connections hit MySQL and get refused.

## Fix

Assign a fixed subnet (`172.20.0.0/24`) to `openpanel_network` and pin each service to a static `ipv4_address`. This guarantees the iptables DNAT rule always resolves to the correct container regardless of start order or IP pool state.

| Container | Static IP |
|---|---|
| `openpanel_dns` | `172.20.0.2` |
| `openpanel_mysql` | `172.20.0.3` |
| `openpanel_redis` | `172.20.0.4` |
| `openpanel` | `172.20.0.5` |
| `openadmin_ftp` | `172.20.0.6` |

> Note: `caddy` uses `network_mode: host` and `clamav` uses `network_mode: ${CLAMAV_DB_AUTOUPDATE}`, so neither is on `openpanel_network` and are unaffected.

## Testing

1. Install OpenPanel fresh — all containers start with stable IPs.
2. `docker restart openpanel` multiple times — port 2083 always routes correctly.
3. `systemctl restart docker` — no stale DNAT rules after restart.